### PR TITLE
Make dropdowns take up space in parent container, so they are not cutoff vertically.

### DIFF
--- a/src/overrideFormioStyles.less
+++ b/src/overrideFormioStyles.less
@@ -13,6 +13,11 @@
   }
 }
 
+.choices__list--dropdown.is-active {
+  position: relative;
+  width: fit-content;
+}
+
 .form-control.selection.dropdown {
   .selectContainer();
   .input--xxl();


### PR DESCRIPTION
Also expand horizontally to show entire text content for each option.