### PR TITLE
Make lookup of skjemanummer for amplitude more forgiving, by checking if form.properties exists first.

### DIFF
--- a/src/util/amplitude.js
+++ b/src/util/amplitude.js
@@ -13,7 +13,7 @@ export const initAmplitude = () => {
 function createEventData(form, customProperties = {}) {
   return {
     skjemanavn: form.title,
-    skjemaId: form.properties.skjemanummer,
+    skjemaId: form.properties ? form.properties.skjemanummer : "",
     ...customProperties,
   };
 }


### PR DESCRIPTION
Fixes bug where test-view fails for forms without skjemanummer, as form.properties does not exist then.