### PR TITLE
Move vedleggskode from component.key to component.properties.vedleggskode

### DIFF
--- a/src/Forms/PrepareSubmitPage.jsx
+++ b/src/Forms/PrepareSubmitPage.jsx
@@ -8,6 +8,7 @@ import { Normaltekst, Sidetittel, Systemtittel } from "nav-frontend-typografi";
 import { scrollToAndSetFocus } from "../util/focus-management";
 import { AppConfigContext } from "../configContext";
 import { useAmplitude } from "../context/amplitude";
+import { genererVedleggKeysSomSkalSendes } from "../util/forsteside";
 
 export const computeDokumentinnsendingURL = (dokumentinnsendingBaseURL, form, submissionData) => {
   let url = `${dokumentinnsendingBaseURL}/opprettSoknadResource?skjemanummer=${encodeURIComponent(
@@ -16,15 +17,8 @@ export const computeDokumentinnsendingURL = (dokumentinnsendingBaseURL, form, su
   if (!submissionData) {
     return url;
   }
-  // basert på at api key for vedlegget er vedlegg<vedleggsId> og at verdien er leggerVedNaa.
-  const vedleggsIder = [];
-  const prefix = "vedlegg";
 
-  Object.entries(submissionData).forEach(([key, value]) => {
-    if (key.startsWith(prefix) && value === "leggerVedNaa" && key.length > prefix.length) {
-      vedleggsIder.push(key.substr(prefix.length));
-    }
-  });
+  const vedleggsIder = genererVedleggKeysSomSkalSendes(form, submissionData);
 
   if (vedleggsIder.length > 0) {
     url = url.concat("&vedleggsIder=", vedleggsIder.join(","));

--- a/src/Forms/PrepareSubmitPage.test.jsx
+++ b/src/Forms/PrepareSubmitPage.test.jsx
@@ -48,31 +48,27 @@ describe("computeDokumentinnsendingURL", () => {
   it("calculate url with vedlegg", () => {
     const url = computeDokumentinnsendingURL(
       "https://example.org",
-      { properties: { skjemanummer: "NAV 76-07.10" } },
-      { vedleggOP: "leggerVedNaa", vedleggQ1: "leggerVedNaa", vedleggF4: "leggerVedNaa" }
+      {
+        components: [
+          { key: "vedleggO9", properties: { vedleggskode: "O9" } },
+          { key: "vedleggQ1", properties: { vedleggskode: "Q1" } },
+          { key: "vedleggF4", properties: { vedleggskode: "F4" } },
+        ],
+        properties: { skjemanummer: "NAV 76-07.10" },
+      },
+      { vedleggO9: "leggerVedNaa", vedleggQ1: "leggerVedNaa", vedleggF4: "leggerVedNaa" }
     );
     expect(url).toEqual(
-      "https://example.org/opprettSoknadResource?skjemanummer=NAV%2076-07.10&erEttersendelse=false&vedleggsIder=OP,Q1,F4"
+      "https://example.org/opprettSoknadResource?skjemanummer=NAV%2076-07.10&erEttersendelse=false&vedleggsIder=O9,Q1,F4"
     );
   });
 
   it("calculate url without vedlegg", () => {
     const url = computeDokumentinnsendingURL(
       "https://example.org",
-      { properties: { skjemanummer: "NAV 76-07.10" } },
+      { components: [], properties: { skjemanummer: "NAV 76-07.10" } },
       {}
     );
     expect(url).toEqual("https://example.org/opprettSoknadResource?skjemanummer=NAV%2076-07.10&erEttersendelse=false");
-  });
-
-  it("includes only the correct prefix vedlegg, drops prefix vedleg", () => {
-    const url = computeDokumentinnsendingURL(
-      "https://example.org",
-      { properties: { skjemanummer: "NAV 76-07.10" } },
-      { vedlegOP: "leggerVedNaa", vedleggR5: "leggerVedNaa", vedlegg: "leggerVedNaa" }
-    );
-    expect(url).toEqual(
-      "https://example.org/opprettSoknadResource?skjemanummer=NAV%2076-07.10&erEttersendelse=false&vedleggsIder=R5"
-    );
   });
 });

--- a/src/util/forsteside.js
+++ b/src/util/forsteside.js
@@ -24,15 +24,14 @@ export function genererSkjemaTittel(skjemaTittel, skjemanummer) {
   return `${skjemanummer} ${skjemaTittel}`;
 }
 
-export function genererVedleggKeysSomSkalSendes(submissionData) {
-  const prefix = "vedlegg";
-  const vedleggKeysSomSkalSendes = [];
-  Object.entries(submissionData).forEach(([key, value]) => {
-    if (key.startsWith(prefix) && value === "leggerVedNaa" && key.length > prefix.length) {
-      vedleggKeysSomSkalSendes.push(key);
-    }
-  });
-  return vedleggKeysSomSkalSendes;
+/**
+ * Basert på at custom property vedleggskode er satt og at verdien er leggerVedNaa.
+ */
+export function genererVedleggKeysSomSkalSendes(form, submissionData) {
+  return flattenComponents(form.components)
+    .filter((component) => component.properties && !!component.properties.vedleggskode)
+    .filter((vedlegg) => submissionData[vedlegg.key] === "leggerVedNaa")
+    .map((vedlegg) => vedlegg.properties.vedleggskode);
 }
 
 export function flattenComponents(components) {
@@ -48,8 +47,10 @@ export function flattenComponents(components) {
 
 export function getVedleggsFelterSomSkalSendes(submissionData, form) {
   const flattenedFormComponents = flattenComponents(form.components);
-  return genererVedleggKeysSomSkalSendes(submissionData).map((vedleggsKey) =>
-    flattenedFormComponents.find((component) => component.key === vedleggsKey)
+  return genererVedleggKeysSomSkalSendes(form, submissionData).map((vedleggsKey) =>
+    flattenedFormComponents.find(
+      (component) => component.properties && component.properties.vedleggskode === vedleggsKey
+    )
   );
 }
 

--- a/src/util/forsteside.test.js
+++ b/src/util/forsteside.test.js
@@ -47,27 +47,27 @@ describe("genererSkjemaTittel", () => {
 
 describe("genererVedleggSomSkalSendes", () => {
   it("adds vedlegg marked as leggerVedNaa", () => {
-    const actual = genererVedleggKeysSomSkalSendes({
+    const actual = genererVedleggKeysSomSkalSendes(formMedVedlegg, {
       vedleggQ7: "leggerVedNaa",
       vedleggO9: "leggerVedNaa",
     });
-    expect(actual).toEqual(["vedleggQ7", "vedleggO9"]);
+    expect(actual).toEqual(["O9", "Q7"]);
   });
 
   it("does not add vedlegg marked as ettersender", () => {
-    const actual = genererVedleggKeysSomSkalSendes({
+    const actual = genererVedleggKeysSomSkalSendes(formMedVedlegg, {
       vedleggQ7: "leggerVedNaa",
       vedleggO9: "ettersender",
     });
-    expect(actual).toEqual(["vedleggQ7"]);
+    expect(actual).toEqual(["Q7"]);
   });
 
   it("does not add vedlegg marked as levertTidligere", () => {
-    const actual = genererVedleggKeysSomSkalSendes({
+    const actual = genererVedleggKeysSomSkalSendes(formMedVedlegg, {
       vedleggQ7: "levertTidligere",
       vedleggO9: "leggerVedNaa",
     });
-    expect(actual).toEqual(["vedleggO9"]);
+    expect(actual).toEqual(["O9"]);
   });
 });
 
@@ -124,6 +124,7 @@ const formMedVedlegg = {
           key: "vedleggO9",
           properties: {
             vedleggstittel: "Bekreftelse fra studiested/skole",
+            vedleggskode: "O9",
           },
           type: "radio",
         },
@@ -142,6 +143,7 @@ const formMedVedlegg = {
           key: "vedleggQ7",
           properties: {
             vedleggstittel: "Dokumentasjon av utgifter i forbindelse med utdanning",
+            vedleggskode: "Q7",
           },
           type: "radio",
         },
@@ -154,8 +156,8 @@ describe("genererVedleggsListe", () => {
   it("generates correct vedleggsListe", () => {
     const actual = genererVedleggsListe(formMedVedlegg, { vedleggQ7: "leggerVedNaa", vedleggO9: "leggerVedNaa" });
     expect(actual).toEqual([
-      "Dokumentasjon av utgifter i forbindelse med utdanning",
       "Bekreftelse fra studiested/skole",
+      "Dokumentasjon av utgifter i forbindelse med utdanning",
     ]);
   });
 
@@ -178,8 +180,8 @@ describe("genererDokumentListeFoersteside", () => {
     );
     expect(actual).toEqual([
       "NAV 76-07.10 Registreringsskjema for tilskudd til utdanning",
-      "Faktura fra utdanningsinstitusjon",
       "Skriftlig bekreftelse på studieplass",
+      "Faktura fra utdanningsinstitusjon",
     ]);
   });
 });
@@ -264,11 +266,11 @@ describe("genererFoerstesideData", () => {
       overskriftstittel: "NAV 76-07.10 Registreringsskjema for tilskudd til utdanning",
       arkivtittel: "NAV 76-07.10 Registreringsskjema for tilskudd til utdanning",
       tema: "OPP",
-      vedleggsliste: ["Dokumentasjon av utgifter i forbindelse med utdanning", "Bekreftelse fra studiested/skole"],
+      vedleggsliste: ["Bekreftelse fra studiested/skole", "Dokumentasjon av utgifter i forbindelse med utdanning"],
       dokumentlisteFoersteside: [
         "NAV 76-07.10 Registreringsskjema for tilskudd til utdanning",
-        "Faktura fra utdanningsinstitusjon",
         "Skriftlig bekreftelse på studieplass",
+        "Faktura fra utdanningsinstitusjon",
       ],
       bruker: {
         brukerId: "12345678911",


### PR DESCRIPTION
Done to support multiple vedlegg referencing the same vedleggskode. (Key must be unique)

Updated tests + deleted one that is no longer relevant