### PR TITLE
Set checkbox value to null instead of undefined when unchecked

### DIFF
--- a/src/customComponents/components/Checkbox.jsx
+++ b/src/customComponents/components/Checkbox.jsx
@@ -33,7 +33,7 @@ const CheckboxWrapper = class extends Component {
         checkboxRef={this.props.checkboxRef}
         aria-describedby={`${component.key}-error`}
         label={component.label}
-        onChange={(event) => this.setValue(!!this.state.value ? undefined : "Ja")}
+        onChange={(event) => this.setValue(!!this.state.value ? null : "Ja")}
         required={component.validate.required}
         checked={this.state.value === "Ja"}
       />


### PR DESCRIPTION
Fixes bug where conditional fields are not refreshed because value does not exist