### PR TITLE
Fix form summary handling of radiopanel component after reverting to native Formio-component

### DIFF
--- a/packages/shared-domain/src/summary/MockedComponentObjectForTest.js
+++ b/packages/shared-domain/src/summary/MockedComponentObjectForTest.js
@@ -31,6 +31,19 @@ const createDummyRadioPanel = (
   values,
 });
 
+const createDummyRadioPanelWithNumberValues = (
+  label = "RadioPanelWithNumberValues",
+  values = [
+    { label: "30-label", value: "30" },
+    { label: "40-label", value: "40" },
+  ]
+) => ({
+  label,
+  key: keyFromLabel(label),
+  type: "radiopanel",
+  values,
+});
+
 const createDummySelectboxes = (
   label = "Selectboxes",
   values = [
@@ -120,6 +133,7 @@ const mockedComponentObjectForTest = {
   createDummyTextfield,
   createDummyEmail,
   createDummyRadioPanel,
+  createDummyRadioPanelWithNumberValues,
   createDummySelectboxes,
   createDummyContentElement,
   createDummyHTMLElement,

--- a/packages/shared-domain/src/summary/formSummaryUtil.js
+++ b/packages/shared-domain/src/summary/formSummaryUtil.js
@@ -11,7 +11,7 @@ function formatValue(component, value, translate) {
   switch (component.type) {
     case "radiopanel":
     case "radio":
-      const valueObject = component.values.find((valueObject) => valueObject.value === value);
+      const valueObject = component.values.find((valueObject) => String(valueObject.value).toString() === String(value).toString());
       if (!valueObject) {
         console.log(`'${value}' is not in ${JSON.stringify(component.values)}`);
         return "";

--- a/packages/shared-domain/src/summary/formSummaryUtil.test.js
+++ b/packages/shared-domain/src/summary/formSummaryUtil.test.js
@@ -9,6 +9,7 @@ const {
   createDummyAlertstripe,
   createDummyNavSkjemagruppe,
   createDummyRadioPanel,
+  createDummyRadioPanelWithNumberValues,
   createDummySelectboxes,
   createDummyTextfield,
   createFormObject,
@@ -91,6 +92,18 @@ describe("When handling component", () => {
     it("are not added if they don't have a submission value", () => {
       const actual = handleComponent(createDummyTextfield(), {}, []);
       expect(actual.find((component) => component.type === "textfield")).toBeUndefined();
+    });
+  });
+
+  describe("radiopanel", () => {
+    it("is correctly added when using string values", () => {
+      const actual = handleComponent(createDummyRadioPanel(), { data: { radiopanel: "yes" }}, [], "", mockedTranslate);
+      expect(actual.find((component) => component.type === "radiopanel").value).toBe("YES-label")
+    });
+
+    it("is correctly added when using string values even though submission data value is a string", () => {
+      const actual = handleComponent(createDummyRadioPanelWithNumberValues(), { data: { radiopanelwithnumbervalues: 40 }}, [], "", mockedTranslate);
+      expect(actual.find((component) => component.type === "radiopanel").value).toBe("40-label")
     });
   });
 


### PR DESCRIPTION
The React component seems to have kept the value as a number, whereas the native component converts it to a string.