### PR TITLE
Set document language when updating currentLanguage.

### DIFF
--- a/packages/shared-components/src/context/languages/useCurrentLanguage.js
+++ b/packages/shared-components/src/context/languages/useCurrentLanguage.js
@@ -17,6 +17,10 @@ const useCurrentLanguage = (languageCodeFromUrl, translations) => {
     }
   }, [languageCodeFromUrl]);
 
+  useEffect(() => {
+    document.documentElement.lang = currentLanguage;
+  }, [currentLanguage])
+
   return { currentLanguage, initialLanguage };
 };
 


### PR DESCRIPTION
Note: This updates language for the entire page. This is technically not correct for the Form Builder, as the builder is always in Norwegian.
A fix would be to set the lang-attribute only on FyllUtRouter, but then page language would not be set in FyllUt.
We will look into/fix this if it becomes an issue in the Form Builder.