### PR TITLE
Bugfix/norsk bokmål valgt rendrer engelsk

### DIFF
--- a/packages/bygger/src/Forms/index.jsx
+++ b/packages/bygger/src/Forms/index.jsx
@@ -58,7 +58,7 @@ export const FormsRouter = ({
         render={({ match }) => {
           const form = getFormFromPath(forms, match.params.formpath);
           return (
-            <I18nProvider loadTranslations={() => loadTranslations(form.path)}>
+            <I18nProvider loadTranslations={() => loadTranslations(form.path)} form={form}>
               <FormPage
                 {...match.params}
                 form={form}

--- a/packages/bygger/src/context/i18n/index.js
+++ b/packages/bygger/src/context/i18n/index.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { mapTranslationsToFormioI18nObject, i18nData } from "@navikt/skjemadigitalisering-shared-components";
+import {getFormTexts} from "../../translations/utils";
 
 export const languagesInNorwegian = {
   "nn-NO": "Norsk nynorsk",
@@ -9,7 +10,14 @@ export const languagesInNorwegian = {
 
 const I18nContext = createContext({});
 
-function I18nProvider({ children, loadTranslations, forGlobal = false }) {
+const extractDefaultI18nNbNoFormTexts = form => {
+  // i18n for nb-NO texts as a workaround to bug https://github.com/formio/formio.js/issues/4465
+  return form
+    ? getFormTexts(form).reduce((i18n, formText) => ({...i18n, [formText.text]: formText.text}), {})
+    : {}
+};
+
+function I18nProvider({ children, loadTranslations, forGlobal = false, form }) {
   const [translations, setTranslations] = useState({});
   const [currentTranslation, setCurrentTranslation] = useState({});
   const [translationsLoaded, setTranslationsLoaded] = useState(false);
@@ -31,11 +39,13 @@ function I18nProvider({ children, loadTranslations, forGlobal = false }) {
 
   useEffect(() => {
     const i18n = mapTranslationsToFormioI18nObject(translations);
+    let nbNoI18nFormTexts = extractDefaultI18nNbNoFormTexts(form);
     setTranslationsForNavForm({
       ...i18n,
       "nb-NO": {
         ...i18n["nb-NO"],
         ...i18nData["nb-NO"],
+        ...nbNoI18nFormTexts
       }
     });
   }, [translations]);

--- a/packages/bygger/src/context/i18n/index.js
+++ b/packages/bygger/src/context/i18n/index.js
@@ -48,7 +48,7 @@ function I18nProvider({ children, loadTranslations, forGlobal = false, form }) {
         ...nbNoI18nFormTexts
       }
     });
-  }, [translations]);
+  }, [translations, form]);
 
   useEffect(() => {
     const withoutCountryNames = (translation) =>

--- a/packages/bygger/src/context/i18n/index.test.js
+++ b/packages/bygger/src/context/i18n/index.test.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import I18nProvider, {useTranslations} from "./index";
+
+const TestComponent = ({setInjectedTranslations}) => {
+  const { translationsForNavForm } = useTranslations();
+  setInjectedTranslations(translationsForNavForm);
+  return (
+    <div>Loaded translations for {Object.keys(translationsForNavForm).length} languages</div>
+  )
+};
+
+const translations = {
+  "nn-NO": {
+    "id": "61828d1945f11b000346b3f6", "translations": {
+      "Testskjema": {"value": "Testskjema", "scope": "local"},
+      "Fornavn": {"value": "Førenamn", "scope": "local"},
+    }
+  },
+  "en": {
+    "id": "6165717c00e3bc0003c9da66", "translations": {
+      "Testskjema": {"value": "Test form", "scope": "local"},
+      "Fornavn": {"value": "First name", "scope": "local"},
+    }
+  }
+};
+
+const form = {
+  title: "Testskjema",
+  components: [
+    {
+      label: "Fornavn",
+      type: "textfield",
+      key: "textfield",
+      inputType: "text",
+      input: true
+    }
+  ]
+};
+
+describe("I18nProvider", () => {
+
+  it("should inject nb-NO default texts in translations along with actual translations", async () => {
+    const setInjectedTranslations = jest.fn();
+    const loadTranslations = () => Promise.resolve(translations);
+    render(
+      <I18nProvider loadTranslations={loadTranslations} form={form}>
+        <TestComponent setInjectedTranslations={setInjectedTranslations} />
+      </I18nProvider>
+    )
+    expect(await screen.findByText("Loaded translations for 3 languages")).toBeInTheDocument();
+    expect(setInjectedTranslations).toHaveBeenCalled();
+    const injectedTranslations = setInjectedTranslations.mock.calls[setInjectedTranslations.mock.calls.length - 1][0];
+    expect(injectedTranslations["nb-NO"].Testskjema).toEqual("Testskjema");
+    expect(injectedTranslations["nb-NO"].Fornavn).toEqual("Fornavn");
+    expect(injectedTranslations["en"].Testskjema).toEqual(translations.en.translations.Testskjema.value);
+    expect(injectedTranslations["en"].Fornavn).toEqual(translations.en.translations.Fornavn.value);
+    expect(injectedTranslations["nn-NO"].Testskjema).toEqual(translations["nn-NO"].translations.Testskjema.value);
+    expect(injectedTranslations["nn-NO"].Fornavn).toEqual(translations["nn-NO"].translations.Fornavn.value);
+  });
+
+});

--- a/packages/shared-components/src/components/NavForm.jsx
+++ b/packages/shared-components/src/components/NavForm.jsx
@@ -26,8 +26,6 @@ import React, { Component, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import EventEmitter from "eventemitter2";
 import { Form as FormioForm, Utils } from "formiojs";
-import { fastCloneDeep } from "formiojs/utils/utils";
-import i18nFormioDefaults from "formiojs/i18n";
 import "nav-frontend-skjema-style";
 import i18nData from "../i18nData";
 import { makeStyles } from "@material-ui/styles";
@@ -44,22 +42,6 @@ const useStyles = makeStyles({
     ...formioFormStyles,
   },
 });
-
-const toLegacy = (i18n) => {
-  // using legacy way of doing translations due to bug https://github.com/formio/formio.js/issues/4465
-  const i18nLegacy = fastCloneDeep(i18nFormioDefaults);
-  Object.keys(i18n).forEach(lang => {
-    if (!i18nLegacy.resources[lang]) {
-      i18nLegacy.resources[lang] = {
-        // extend the default translations (validations, buttons etc.) in case they are not in the options.
-        translation: Object.assign(fastCloneDeep(i18nFormioDefaults.resources.en.translation), i18n[lang])
-      }
-    } else {
-      Object.assign(i18nLegacy.resources[lang].translation, i18n[lang]);
-    }
-  });
-  return i18nLegacy;
-};
 
 const NavForm = (props) => {
 
@@ -79,10 +61,9 @@ const NavForm = (props) => {
 
   const createWebformInstance = (srcOrForm) => {
     const {formioform, formReady, language, i18n} = props;
-    const i18nLegacy = toLegacy(i18n);
     instance = new (formioform || FormioForm)(element, srcOrForm, {
       language,
-      i18n: i18nLegacy,
+      i18n,
       sanitizeConfig: SANITIZE_CONFIG,
       events: NavForm.getDefaultEmitter()
     });

--- a/packages/shared-components/src/components/NavForm.test.jsx
+++ b/packages/shared-components/src/components/NavForm.test.jsx
@@ -28,8 +28,8 @@ describe("NavForm", () => {
 
   describe("i18n", () => {
 
-    it("should render norwegian label as specified in form definition", async () => {
-      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+    it("should render norwegian label as specified in i18n", async () => {
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"Fornavn": "Fornavn", "submit": "Lagre"}};
       await renderNavForm({
         form: testskjemaForOversettelser,
         language: "nb-NO",
@@ -40,7 +40,7 @@ describe("NavForm", () => {
     });
 
     it("should render the english label as specified in i18n", async () => {
-      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"Fornavn": "Fornavn", "submit": "Lagre"}};
       await renderNavForm({
         form: testskjemaForOversettelser,
         language: "en",
@@ -51,7 +51,7 @@ describe("NavForm", () => {
     });
 
     it("should change language from norwegian to english", async () => {
-      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"Fornavn": "Fornavn", "submit": "Lagre"}};
       const {rerender} = await renderNavForm({
         form: testskjemaForOversettelser,
         language: "nb-NO",

--- a/packages/shared-components/src/components/NavForm.test.jsx
+++ b/packages/shared-components/src/components/NavForm.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import {render, screen, waitFor} from "@testing-library/react";
+import NavForm from "./NavForm";
+
+const testskjemaForOversettelser = {
+  title: "Testskjema",
+  components: [
+    {
+      label: "Fornavn",
+      type: "textfield",
+      key: "textfield",
+      inputType: "text",
+      input: true
+    }
+  ],
+};
+
+describe("NavForm", () => {
+
+  const renderNavForm = async (props) => {
+    const formReady = jest.fn();
+    const renderReturn = render(
+      <NavForm {...props} formReady={formReady} />
+    );
+    await waitFor(() => expect(formReady).toHaveBeenCalledTimes(1));
+    return renderReturn;
+  }
+
+  describe("i18n", () => {
+
+    it("should render norwegian label as specified in form definition", async () => {
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+      await renderNavForm({
+        form: testskjemaForOversettelser,
+        language: "nb-NO",
+        i18n
+      });
+      const fornavnInput = await screen.findByLabelText("Fornavn");
+      expect(fornavnInput).toBeInTheDocument();
+    });
+
+    it("should render the english label as specified in i18n", async () => {
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+      await renderNavForm({
+        form: testskjemaForOversettelser,
+        language: "en",
+        i18n
+      });
+      const fornavnInput = await screen.findByLabelText("First name");
+      expect(fornavnInput).toBeInTheDocument();
+    });
+
+    it("should change language from norwegian to english", async () => {
+      const i18n = {"en": {"Fornavn": "First name"}, "nb-NO": {"submit": "Lagre"}};
+      const {rerender} = await renderNavForm({
+        form: testskjemaForOversettelser,
+        language: "nb-NO",
+        i18n
+      });
+      expect(await screen.findByLabelText("Fornavn")).toBeInTheDocument();
+
+      rerender(
+        <NavForm
+          form={testskjemaForOversettelser}
+          language="en"
+          i18n={i18n}
+        />
+      );
+      expect(await screen.findByLabelText("First name")).toBeInTheDocument();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Workaround: Sende inn nb-NO translations for alle tekster i et skjema (tekst til samme tekst)

Har opprettet https://github.com/formio/formio.js/issues/4465, men etter en kikk på andre bugs som ligger der så har jeg ikke tro på at det vil bli fikset de nærmeste månedene, så vi trenger en workaround.