### PR TITLE
Load form should receive and handle object or null, instead of empty array.

### DIFF
--- a/packages/fyllut/server/server.js
+++ b/packages/fyllut/server/server.js
@@ -126,8 +126,10 @@ const loadForms = async () => {
 
 const loadForm = async (formPath) => {
   return useFormioApi
-    ? await fetchFromFormioApi(`${formioProjectUrl}/form?type=form&tags=nav-skjema&path=${formPath}`)
-    : await loadFileFromDirectory(skjemaDir, formPath, []);
+    ? await fetchFromFormioApi(`${formioProjectUrl}/form?type=form&tags=nav-skjema&path=${formPath}`).then((results) =>
+        results.length > 0 ? results[0] : null
+      )
+    : await loadFileFromDirectory(skjemaDir, formPath, null);
 };
 
 const loadTranslations = async (formPath) => {
@@ -157,7 +159,7 @@ skjemaApp.get("/config", async (req, res) => {
 });
 
 skjemaApp.get("/forms/:formPath", async (req, res) => {
-  const form = await loadForm(req.params.formPath).then((results) => (results.length === 1 ? results[0] : null));
+  const form = await loadForm(req.params.formPath);
   if (!form) {
     return res.sendStatus(404);
   }


### PR DESCRIPTION
Moved handling of array return from formio API to the fetch call.
Also changed check to results.length > 0, instead of the strict results.length === 1 to make it more robust.