### PR TITLE
Fix error where global translations page fails if a saved skjematekst is missing translated text

### DIFF
--- a/packages/bygger/src/translations/global/getCurrenttranslationsReducer.ts
+++ b/packages/bygger/src/translations/global/getCurrenttranslationsReducer.ts
@@ -17,7 +17,7 @@ const getCurrenttranslationsReducer = (state: Array<any>, action: ReducerActionT
       const newState = Object.keys(action.payload.translations).map((originalText) => ({
         id: guid(),
         originalText,
-        translatedText: action.payload.translations[originalText].value,
+        translatedText: action.payload.translations[originalText].value || "",
       }));
       if (newState.length > 0) {
         return newState;


### PR DESCRIPTION
Add fallback to empty text if translated text is missing