### PR TITLE
TypeError: req.correlationId is not a function

### DIFF
--- a/packages/fyllut/server/server.js
+++ b/packages/fyllut/server/server.js
@@ -20,11 +20,10 @@ import { fetchFromFormioApi, loadAllJsonFilesFromDirectory, loadFileFromDirector
 const app = express();
 const skjemaApp = express();
 
+skjemaApp.use(correlator());
 skjemaApp.use(cors());
-// Parse application/json
 skjemaApp.use(express.json({ limit: "50mb" }));
 skjemaApp.use(express.urlencoded({ extended: true, limit: "50mb" }));
-skjemaApp.use(correlator());
 skjemaApp.set("views", buildDirectory);
 skjemaApp.set("view engine", "mustache");
 skjemaApp.engine("html", mustacheExpress());


### PR DESCRIPTION
req.correlationId is not a function ser ut til å føre til at pod restartes. Flytter correlation-middleware helt først siden det er denne som legger på correlationId-function på request.