### PR TITLE
addNullChecksToChainedLookup should not change partial expressions

### DIFF
--- a/packages/shared-components/src/formio-overrides/utils-overrides.js
+++ b/packages/shared-components/src/formio-overrides/utils-overrides.js
@@ -17,7 +17,7 @@ function addNullChecksToChainedLookup(chainedLookup, originalString) {
   for (let j = 1; j < chainedLookupParts.length; j++) {
     safeChainedLookup = safeChainedLookup + " && " + chainedLookupParts.slice(0, j + 1).join(".");
   }
-  return originalString.replace(new RegExp(chainedLookup + "\\b", "g"), `(${safeChainedLookup})`);
+  return originalString.replace(new RegExp(`\\b${chainedLookup}\\b`, "g"), `(${safeChainedLookup})`);
 }
 
 function mapChainedLookups(text) {

--- a/packages/shared-components/src/formio-overrides/utils-overrides.js
+++ b/packages/shared-components/src/formio-overrides/utils-overrides.js
@@ -17,7 +17,7 @@ function addNullChecksToChainedLookup(chainedLookup, originalString) {
   for (let j = 1; j < chainedLookupParts.length; j++) {
     safeChainedLookup = safeChainedLookup + " && " + chainedLookupParts.slice(0, j + 1).join(".");
   }
-  return originalString.replace(new RegExp(chainedLookup, "g"), `(${safeChainedLookup})`);
+  return originalString.replace(new RegExp(chainedLookup + "\\b", "g"), `(${safeChainedLookup})`);
 }
 
 function mapChainedLookups(text) {

--- a/packages/shared-components/src/formio-overrides/utils-overrides.test.js
+++ b/packages/shared-components/src/formio-overrides/utils-overrides.test.js
@@ -40,6 +40,13 @@ describe("sanitizeJavaScriptCode", () => {
     expect(sanitizeJavaScriptCode(inputWithMultipleEqualChainedLookups)).toEqual("show = (a1 && a1.b2) === 'c'");
   });
 
+  it("will not change a partial expression", () => {
+    const inputWithTwoChainedWhereOneIsAPartialOfTheOther =
+      "show = anObject.aString === 'c' || anObject.aString1 === 'd'";
+    const actual = sanitizeJavaScriptCode(inputWithTwoChainedWhereOneIsAPartialOfTheOther);
+    expect(actual).toEqual("show = (anObject && anObject.aString) === 'c' || (anObject && anObject.aString1) === 'd'");
+  });
+
   describe("When the code includes function calls", () => {
     it("does not add null checks for functions on instance", () => {
       const inputWithInstanceFunctionCall = "valid = instance.validate(input)";

--- a/packages/shared-components/src/formio-overrides/utils-overrides.test.js
+++ b/packages/shared-components/src/formio-overrides/utils-overrides.test.js
@@ -47,6 +47,13 @@ describe("sanitizeJavaScriptCode", () => {
     expect(actual).toEqual("show = (anObject && anObject.aString) === 'c' || (anObject && anObject.aString1) === 'd'");
   });
 
+  it("will not change a partial expression that ends in an equal expression to another complete expression", () => {
+    const inputWithOneChainedExpressionEndingInAnotherExpression =
+      "show = anObject.aString === 'c' || Object.aString === 'd'";
+    const actual = sanitizeJavaScriptCode(inputWithOneChainedExpressionEndingInAnotherExpression);
+    expect(actual).toEqual("show = (anObject && anObject.aString) === 'c' || (Object && Object.aString) === 'd'");
+  });
+
   describe("When the code includes function calls", () => {
     it("does not add null checks for functions on instance", () => {
       const inputWithInstanceFunctionCall = "valid = instance.validate(input)";


### PR DESCRIPTION
E.g. expressions obj.key and obj.key1 should not cause obj.key1 to be changed to (obj && obj.key)1, but (obj && obj.key1)

Fixes https://trello.com/c/2peFS4Yw/822-advanced-conditionals-knekker-hvis-uttrykket-sjekker-opp-felt-med-n%C3%B8kler-som-ligner