### PR TITLE
FormioReactComponent keeps the value if it is cleared, causing Datepicker to reset the value.

### DIFF
--- a/packages/shared-components/src/customComponents/FormioReactComponent.jsx
+++ b/packages/shared-components/src/customComponents/FormioReactComponent.jsx
@@ -130,7 +130,7 @@ export default class FormioReactComponent extends Field {
    */
   updateValue = (value, flags) => {
     flags = flags || {};
-    const newValue = value === undefined || value === null ? this.getValue() : value;
+    const newValue = value === undefined || value === null ? undefined : value;
     const changed = newValue !== undefined ? this.hasChanged(newValue, this.dataValue) : false;
     this.dataValue = Array.isArray(newValue) ? [...newValue] : newValue;
 

--- a/packages/shared-components/src/customComponents/FormioReactComponent.jsx
+++ b/packages/shared-components/src/customComponents/FormioReactComponent.jsx
@@ -130,7 +130,7 @@ export default class FormioReactComponent extends Field {
    */
   updateValue = (value, flags) => {
     flags = flags || {};
-    const newValue = value === undefined || value === null ? undefined : value;
+    const newValue = value === undefined || value === null ? this.getValue() : value;
     const changed = newValue !== undefined ? this.hasChanged(newValue, this.dataValue) : false;
     this.dataValue = Array.isArray(newValue) ? [...newValue] : newValue;
 

--- a/packages/shared-components/src/customComponents/components/NavDatepicker.jsx
+++ b/packages/shared-components/src/customComponents/components/NavDatepicker.jsx
@@ -26,8 +26,9 @@ const DatovelgerWrapper = ({ component, onChange, value, isValid, locale, readOn
       id={component.id}
       valgtDato={dato}
       onChange={(d) => {
-        setDato(d);
-        onChange(d);
+        const newValue = d === undefined || d === null ? "" : d;
+        setDato(newValue);
+        onChange(newValue);
       }}
       datoErGyldig={isValid}
       visÅrVelger={component.visArvelger}

--- a/packages/shared-components/src/template/templates/navdesign/wizard/form.ejs
+++ b/packages/shared-components/src/template/templates/navdesign/wizard/form.ejs
@@ -2,9 +2,9 @@
   <div style="position: relative;">
     {{ ctx.wizardHeader }}
     <main id="maincontent" tabIndex="-1">
-      <h2 class="margin-bottom-default typo-innholdstittel">{{ctx.t(ctx.panels[ctx.currentPage].title)}}</h2>
-      <form class="wizard-page" ref="{{ctx.wizardKey}}">
-        {{ctx.components}}
+      <h2 id="form-id" class="margin-bottom-default typo-innholdstittel">{{ctx.t(ctx.panels[ctx.currentPage].title)}}</h2>
+      <form aria-labelledby="form-id" class="wizard-page" ref="{{ctx.wizardKey}}">
+        {{ ctx.components }}
         {{ ctx.wizardNav }}
       </form>
     </main>


### PR DESCRIPTION
This change will affect every Formio React component, but since the only one in use is the Datepicker, this seems safe.