### PR TITLE
NavDatepicker submission is cleared when navigating to SummaryPage.

### DIFF
--- a/packages/shared-components/src/components/NavForm.jsx
+++ b/packages/shared-components/src/components/NavForm.jsx
@@ -141,13 +141,6 @@ const NavForm = (props) => {
     overrideFormioWizardNextPageAndSubmit(props.loggSkjemaStegFullfort, props.loggSkjemaValideringFeilet);
   }, [props.loggSkjemaStegFullfort, props.loggSkjemaValideringFeilet]);
 
-  useEffect(() => {
-    const { submission } = props;
-    if (formio && submission) {
-      formio.submission = submission;
-    }
-  }, [props.submission, formio]);
-
   return <div className={props.className} data-testid="formMountElement" ref={(el) => (element = el)} />;
 };
 


### PR DESCRIPTION
It is not quite clear *why* this code causes that, but it probably has something to do with trying to update a form that has been removed, and the React components will then be hidden.
Maybe the others "live on" in the Formio-object? Anyhow, this fixes the problem, and doesn't appear to cause any new bugs.