### PR TITLE
Feature/check-for-breaking-changes-when-doing-migration

### DIFF
--- a/packages/bygger/server/backend/migration/migrationScripts.test.js
+++ b/packages/bygger/server/backend/migration/migrationScripts.test.js
@@ -269,12 +269,6 @@ describe("Migration scripts", () => {
       },
     };
 
-    /*const componentWithConditionalOnValues = {
-      key: "comp-with-conditional-on-values",
-      id: "comp-with-conditional-on-values",
-      label: "Component with conditional on values",
-    };*/
-
     function createAffectedComponent(...diffs) {
       return diffs.map((diff) => ({ diff }));
     }
@@ -287,7 +281,6 @@ describe("Migration scripts", () => {
         key_ORIGINAL: "comp-that-is-changed",
         label: "Component that is changed",
       });
-      //expect(testForm).toEqual([]);
       const actual = getBreakingChanges(testForm, affectedComponents);
       expect(actual).toEqual([
         {

--- a/packages/bygger/src/migration/BreakingChangesWarning.tsx
+++ b/packages/bygger/src/migration/BreakingChangesWarning.tsx
@@ -1,0 +1,36 @@
+import AlertStripe from "nav-frontend-alertstriper";
+import React from "react";
+import { BreakingChanges } from "../../types/migration";
+
+type BreakingChangesWarningProps = {
+  breakingChanges: BreakingChanges[];
+};
+
+const BreakingChangesWarning = ({ breakingChanges }: BreakingChangesWarningProps) => (
+  <AlertStripe type="feil">
+    Andre komponenter har avhengigheter til denne komponenten som kan brekkes av migreringen. Vennligst se over følgende
+    avhengigheter:
+    <ul>
+      {breakingChanges.map(({ componentWithDependencies, dependentComponents }) => {
+        const componentLabel = componentWithDependencies.label || componentWithDependencies.label_ORIGINAL;
+        const componentKey = componentWithDependencies.key || componentWithDependencies.key_ORIGINAL;
+        return (
+          <li key={componentWithDependencies.id}>
+            <p>
+              {componentLabel} ({componentKey}) refereres til av:
+            </p>
+            <ul>
+              {dependentComponents.map(({ key, label }) => (
+                <li>
+                  {label} ({key})
+                </li>
+              ))}
+            </ul>
+          </li>
+        );
+      })}
+    </ul>
+  </AlertStripe>
+);
+
+export default BreakingChangesWarning;

--- a/packages/bygger/src/migration/BreakingChangesWarning.tsx
+++ b/packages/bygger/src/migration/BreakingChangesWarning.tsx
@@ -8,8 +8,8 @@ type BreakingChangesWarningProps = {
 
 const BreakingChangesWarning = ({ breakingChanges }: BreakingChangesWarningProps) => (
   <AlertStripe type="feil">
-    Andre komponenter har avhengigheter til denne komponenten som kan brekkes av migreringen. Vennligst se over følgende
-    avhengigheter:
+    Migreringen vil gjøre endringer på komponenter som kan brekke avhengigheter i andre komponenter. Normalt vil dette
+    skyldes endringer på key, samt verdier i radio eller nedtrekkslister. Vennligst se over følgende avhengigheter:
     <ul>
       {breakingChanges.map(({ componentWithDependencies, dependentComponents }) => {
         const componentLabel = componentWithDependencies.label || componentWithDependencies.label_ORIGINAL;

--- a/packages/bygger/src/migration/MigrationDryRunResults.tsx
+++ b/packages/bygger/src/migration/MigrationDryRunResults.tsx
@@ -4,6 +4,7 @@ import { Undertittel } from "nav-frontend-typografi";
 import React from "react";
 import { Link } from "react-router-dom";
 import { DryRunResult } from "../../types/migration";
+import BreakingChangesWarning from "./BreakingChangesWarning";
 
 const useStyles = makeStyles({
   titleRow: {
@@ -33,35 +34,40 @@ const MigrationDryRunResults = ({
 
   return (
     <ul>
-      {dryRunResults.map((result) => (
-        <li key={result.skjemanummer}>
-          <div className={styles.titleRow}>
-            <Undertittel className={styles.title}>
-              {result.title} ({result.skjemanummer})
-            </Undertittel>
-            {result.changed > 0 && (
-              <Checkbox
-                label={"Inkluder i migrering"}
-                checked={selectedPaths.includes(result.path)}
-                onChange={(event) => {
-                  if (event.target.checked) {
-                    onChange([...selectedPaths, result.path]);
-                  } else {
-                    onChange(selectedPaths.filter((path) => path !== result.path));
-                  }
-                }}
-              />
-            )}
-          </div>
-          <p>
-            Antall komponenter som vil bli påvirket av migreringen: {result.changed} av {result.found}
-          </p>
-          {result.diff.length > 0 && <pre>{JSON.stringify(result.diff, null, 2)}</pre>}
-          <Link className="knapp margin-bottom-default" to={getPreviewUrl(result.path)}>
-            Forhåndsvis
-          </Link>
-        </li>
-      ))}
+      {dryRunResults.map((result) => {
+        const { breakingChanges } = result;
+        const hasBreakingChanges = breakingChanges && breakingChanges.length > 0;
+        return (
+          <li key={result.skjemanummer}>
+            <div className={styles.titleRow}>
+              <Undertittel className={styles.title}>
+                {result.title} ({result.skjemanummer})
+              </Undertittel>
+              {result.changed > 0 && (
+                <Checkbox
+                  label={"Inkluder i migrering"}
+                  checked={selectedPaths.includes(result.path)}
+                  onChange={(event) => {
+                    if (event.target.checked) {
+                      onChange([...selectedPaths, result.path]);
+                    } else {
+                      onChange(selectedPaths.filter((path) => path !== result.path));
+                    }
+                  }}
+                />
+              )}
+            </div>
+            <p>
+              Antall komponenter som vil bli påvirket av migreringen: {result.changed} av {result.found}
+            </p>
+            {hasBreakingChanges && <BreakingChangesWarning breakingChanges={breakingChanges} />}
+            {result.diff.length > 0 && <pre>{JSON.stringify(result.diff, null, 2)}</pre>}
+            <Link className="knapp margin-bottom-default" to={getPreviewUrl(result.path)}>
+              Forhåndsvis
+            </Link>
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/packages/bygger/src/migration/MigrationPage.tsx
+++ b/packages/bygger/src/migration/MigrationPage.tsx
@@ -67,9 +67,11 @@ export const getUrlWithMigrateSearchParams = (
 };
 
 const getMigrationResultsMatchingSearchFilters = (dryRunResults: DryRunResults) =>
-  Object.values(dryRunResults)
-    .filter((results) => results.found > 0)
-    .sort((a, b) => b.found - a.found);
+  dryRunResults
+    ? Object.values(dryRunResults)
+        .filter((results) => results.found > 0)
+        .sort((a, b) => b.found - a.found)
+    : [];
 
 const getUrlParamMap = (params, name) => {
   const param = params.get(name);

--- a/packages/bygger/types/migration.d.ts
+++ b/packages/bygger/types/migration.d.ts
@@ -19,6 +19,38 @@ export type FormMigrationDiff =
     }
   | { [property: string]: { _ORIGINAL: any; _NEW: any } };
 
+export type ComponentWithDependencies = {
+  id: string;
+  [key: string]: string;
+} & (
+  | {
+      key: string;
+    }
+  | {
+      key_ORIGINAL: string;
+      key_NEW: string;
+    }
+) &
+  (
+    | {
+        label: string;
+      }
+    | {
+        label_ORIGINAL: string;
+        label_NEW: string;
+      }
+  );
+
+export interface DependentComponents {
+  key: string;
+  label: string;
+}
+
+export interface BreakingChanges {
+  componentWithDependencies: ComponentWithDependencies;
+  dependentComponents: DependentComponents[];
+}
+
 export interface DryRunResult {
   skjemanummer: string;
   name: string;
@@ -27,6 +59,7 @@ export interface DryRunResult {
   found: number;
   changed: number;
   diff: FormMigrationDiff[];
+  breakingChanges?: BreakingChanges[];
 }
 
 export interface DryRunResults {

--- a/packages/shared-domain/src/index.js
+++ b/packages/shared-domain/src/index.js
@@ -5,7 +5,7 @@ import TEXTS from "./texts";
 import featureUtils from "./utils/featureUtils";
 import { guid } from "./utils/guid";
 import localizationUtils from "./utils/localization";
-import navFormUtils from "./utils/navFormUtils";
+import navFormUtils, { findDependentComponents } from "./utils/navFormUtils";
 import objectUtils from "./utils/objectUtils";
 import stringUtils from "./utils/stringUtils";
 
@@ -20,4 +20,5 @@ export {
   featureUtils,
   languagesUtil,
   guid,
+  findDependentComponents,
 };

--- a/packages/shared-domain/src/utils/navFormUtils.js
+++ b/packages/shared-domain/src/utils/navFormUtils.js
@@ -1,4 +1,3 @@
-import FormioUtils from "formiojs/utils";
 import { camelCase } from "./stringUtils";
 
 export const toFormPath = (text) => camelCase(text).toLowerCase();
@@ -22,11 +21,12 @@ export function flattenComponents(components) {
 }
 
 function isKeyInText(key, text) {
-  return text && text.search(`data.${key}[^a-zA-z0-9_-]`) > -1;
+  console.log(`Is ${key} in '${text}': ${text && text.search(`\\w+.${key}[^a-zA-z0-9_-]`) > -1}`);
+  return text && text.search(`\\w+.${key}[^a-zA-z0-9_-]`) > -1;
 }
 
 function areAnyPathsInText(paths, text) {
-  return text && paths.some((key) => isKeyInText(key, text));
+  return text && text !== "" && paths.some((key) => isKeyInText(key, text));
 }
 
 function calculatesValueBasedOn(paths, component) {
@@ -85,15 +85,22 @@ const findById = (id, components) => {
 };
 
 export const findDependentComponents = (id, form) => {
-  const idToPathMapping = {};
+  console.log("Find dependent components");
+  /*const idToPathMapping = {};
   FormioUtils.eachComponent(form.components, (component, path) => {
+    console.log("Path", path);
+    console.log("Component", JSON.stringify(component, null, 2));
     idToPathMapping[component.id] = path;
-  });
+  });*/
 
   const component = findById(id, form.components);
   if (component) {
-    const downstreamPaths = flattenComponents([component]).map((comp) => idToPathMapping[comp.id]);
+    //const downstreamPaths = flattenComponents([component]).map((comp) => idToPathMapping[comp.id]);
+    const downstreamPaths = flattenComponents([component]).map((comp) => comp.key);
+    console.log("Recursively find dependent components for", id, downstreamPaths);
     return recursivelyFindDependentComponents(id, downstreamPaths, form.components);
+  } else {
+    console.log("Did not find component", id);
   }
   return [];
 };

--- a/packages/shared-domain/src/utils/navFormUtils.js
+++ b/packages/shared-domain/src/utils/navFormUtils.js
@@ -1,3 +1,4 @@
+import FormioUtils from "formiojs/utils";
 import { camelCase } from "./stringUtils";
 
 export const toFormPath = (text) => camelCase(text).toLowerCase();
@@ -84,15 +85,14 @@ const findById = (id, components) => {
 };
 
 export const findDependentComponents = (id, form) => {
-  /*const idToPathMapping = {};
+  const idToPathMapping = {};
   FormioUtils.eachComponent(form.components, (component, path) => {
     idToPathMapping[component.id] = path;
-  });*/
+  });
 
   const component = findById(id, form.components);
   if (component) {
-    //const downstreamPaths = flattenComponents([component]).map((comp) => idToPathMapping[comp.id]);
-    const downstreamPaths = flattenComponents([component]).map((comp) => comp.key);
+    const downstreamPaths = flattenComponents([component]).map((comp) => idToPathMapping[comp.id]);
     return recursivelyFindDependentComponents(id, downstreamPaths, form.components);
   }
   return [];

--- a/packages/shared-domain/src/utils/navFormUtils.js
+++ b/packages/shared-domain/src/utils/navFormUtils.js
@@ -21,7 +21,6 @@ export function flattenComponents(components) {
 }
 
 function isKeyInText(key, text) {
-  console.log(`Is ${key} in '${text}': ${text && text.search(`\\w+.${key}[^a-zA-z0-9_-]`) > -1}`);
   return text && text.search(`\\w+.${key}[^a-zA-z0-9_-]`) > -1;
 }
 
@@ -85,11 +84,8 @@ const findById = (id, components) => {
 };
 
 export const findDependentComponents = (id, form) => {
-  console.log("Find dependent components");
   /*const idToPathMapping = {};
   FormioUtils.eachComponent(form.components, (component, path) => {
-    console.log("Path", path);
-    console.log("Component", JSON.stringify(component, null, 2));
     idToPathMapping[component.id] = path;
   });*/
 
@@ -97,10 +93,7 @@ export const findDependentComponents = (id, form) => {
   if (component) {
     //const downstreamPaths = flattenComponents([component]).map((comp) => idToPathMapping[comp.id]);
     const downstreamPaths = flattenComponents([component]).map((comp) => comp.key);
-    console.log("Recursively find dependent components for", id, downstreamPaths);
     return recursivelyFindDependentComponents(id, downstreamPaths, form.components);
-  } else {
-    console.log("Did not find component", id);
   }
   return [];
 };

--- a/packages/shared-domain/src/utils/navFormUtils.js
+++ b/packages/shared-domain/src/utils/navFormUtils.js
@@ -21,6 +21,20 @@ export function flattenComponents(components) {
   }, []);
 }
 
+function calculatesBasedOn(paths, component) {
+  return (
+    component.calculateValue && paths.some((key) => component.calculateValue.search(`data.${key}[^a-zA-z0-9_-]`) > -1)
+  );
+}
+
+function validatesBasedOn(paths, component) {
+  return (
+    component.validate &&
+    component.validate.custom &&
+    paths.some((key) => component.validate.custom.search(`data.${key}[^a-zA-z0-9_-]`) > -1)
+  );
+}
+
 function hasConditionalOn(paths, component) {
   return (
     (component.conditional &&
@@ -36,7 +50,11 @@ const recursivelyFindDependentComponents = (mainId, downstreamPaths, comps) => {
   const dependentKeys = [];
   comps.forEach((comp) => {
     if (comp.id !== mainId) {
-      if (hasConditionalOn(downstreamPaths, comp)) {
+      if (
+        hasConditionalOn(downstreamPaths, comp) ||
+        validatesBasedOn(downstreamPaths, comp) ||
+        calculatesBasedOn(downstreamPaths, comp)
+      ) {
         dependentKeys.push({ key: comp.key, label: comp.label });
       }
       if (comp.components?.length > 0) {

--- a/packages/shared-domain/src/utils/navFormUtils.js
+++ b/packages/shared-domain/src/utils/navFormUtils.js
@@ -21,7 +21,7 @@ export function flattenComponents(components) {
 }
 
 function isKeyInText(key, text) {
-  return text && text.search(`\\w+.${key}[^a-zA-z0-9_-]`) > -1;
+  return text && text.search(`\\w+\\.${key}[^a-zA-z0-9_-]`) > -1;
 }
 
 function areAnyPathsInText(paths, text) {

--- a/packages/shared-domain/src/utils/navFormUtils.test.js
+++ b/packages/shared-domain/src/utils/navFormUtils.test.js
@@ -441,8 +441,134 @@ describe("navFormUtils", () => {
       expect(actualForm.components).toHaveLength(0);
     });
 
-    describe("A form with a component that calculates value based on another", () => {});
+    describe("A form with a component that calculates value based on another", () => {
+      const formWithComponentsThatCalulateValueBasedOnAnother = {
+        id: "myForm",
+        title: "Form with components that calculate value based on another",
+        components: [
+          {
+            id: "panel1",
+            title: "Panel 1",
+            type: "panel",
+            components: [
+              {
+                key: "someCheckbox",
+                label: "Some checkbox",
+                type: "navCheckbox",
+                id: "navCheckbox1",
+              },
+            ],
+          },
+          {
+            id: "panel2",
+            title: "Panel 2",
+            type: "panel",
+            components: [
+              {
+                id: "number1",
+                key: "aComponentThatCalculatesValueBasedOnSomeCheckbox",
+                label: "A component that calculates value based on someCheckbox",
+                type: "number",
+                calculateValue: "value = data.someCheckbox === true ? 1000 : 0",
+                readOnly: true,
+              },
+            ],
+          },
+        ],
+      };
+      const actual = findDependentComponents("navCheckbox1", formWithComponentsThatCalulateValueBasedOnAnother);
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "aComponentThatCalculatesValueBasedOnSomeCheckbox",
+          }),
+        ])
+      );
+    });
 
-    describe("A form with a component that validates based on another", () => {});
+    describe("A form with a component that validates based on another", () => {
+      const formWithComponentsThatValidatesBasedOnAnother = {
+        id: "myForm",
+        title: "Form with components that calculate value based on another",
+        components: [
+          {
+            id: "panel1",
+            title: "Panel 1",
+            type: "panel",
+            components: [
+              {
+                key: "someCheckbox",
+                label: "Some checkbox",
+                type: "navCheckbox",
+                id: "navCheckbox1",
+              },
+            ],
+          },
+          {
+            id: "panel2",
+            title: "Panel 2",
+            type: "panel",
+            components: [
+              {
+                id: "radio1",
+                key: "aComponentThatValidatesBasedOnSomeCheckbox",
+                label: "A component that validates based on someCheckbox",
+                type: "radio",
+                validate: {
+                  custom:
+                    "valid = data.someCheckbox === true ? input.a : 'You have to choose A if Some Checkbox is checked",
+                },
+                readOnly: true,
+              },
+              {
+                id: "radio2",
+                key: "aComponentThatHasJSONLogicValidationBasedOnSomeCheckbox",
+                label: "A component that validates based on someCheckbox",
+                type: "radio",
+                validate: {
+                  json: {
+                    if: [
+                      {
+                        "===": [
+                          {
+                            var: "data.someCheckbox",
+                          },
+                          true,
+                        ],
+                        if: [
+                          {
+                            "===": [
+                              {
+                                var: "input",
+                              },
+                              "B",
+                            ],
+                          },
+                        ],
+                      },
+                      true,
+                      "You have to choose A if Some Checkbox is checked",
+                    ],
+                  },
+                },
+                readOnly: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const actual = findDependentComponents("navCheckbox1", formWithComponentsThatValidatesBasedOnAnother);
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "aComponentThatValidatesBasedOnSomeCheckbox",
+          }),
+          expect.objectContaining({
+            key: "aComponentThatHasJSONLogicValidationBasedOnSomeCheckbox",
+          }),
+        ])
+      );
+    });
   });
 });

--- a/packages/shared-domain/src/utils/navFormUtils.test.js
+++ b/packages/shared-domain/src/utils/navFormUtils.test.js
@@ -440,5 +440,9 @@ describe("navFormUtils", () => {
       });
       expect(actualForm.components).toHaveLength(0);
     });
+
+    describe("A form with a component that calculates value based on another", () => {});
+
+    describe("A form with a component that validates based on another", () => {});
   });
 });


### PR DESCRIPTION
Had to expand the dependency check to also account for dependencies in validation and calculateValue (in addition to conditionals).

One issue that has not been resolved, is that the existing code does not account for JS-conditional or JS-validation that refers to components inside of datagrids. Those will refer to "row.COMPONENT_KEY" or "rad.COMPONENT_KEY" (the row variable name will be decided by the JS-writer), and as such will not be matched by the full path of the component.

I tried changing the code to only check for key (COMPONENT_KEY above), but that broke existing tests. I think it still might be correct, but didn't want to deal with the tests at this moment. We should revisit this later/in code review or show-and-tell, so everyone understand the implications.