### PR TITLE
Refactor FormioReactComponent to remove boilerplates for implementing components

### DIFF
--- a/packages/shared-components/src/customComponents/components/Checkbox.jsx
+++ b/packages/shared-components/src/customComponents/components/Checkbox.jsx
@@ -37,8 +37,6 @@ const CheckboxWrapper = ({ component, checkboxRef, translate, onChange, value })
 };
 
 export default class CheckboxComponent extends FormioReactComponent {
-  input = null;
-
   /**
    * This function tells the form builder about your component. It's name, icon and what group it should be in.
    *
@@ -197,47 +195,5 @@ export default class CheckboxComponent extends FormioReactComponent {
       />,
       element
     );
-  }
-
-  /**
-   * This function is called when the DIV has been rendered and added to the DOM. You can now instantiate the react component.
-   *
-   * @param DOMElement
-   * #returns ReactInstance
-   */
-  attachReact(element) {
-    this.reactElement = element;
-    this.renderReact(element);
-    return this.reactElement;
-  }
-
-  /**
-   * Automatically detach any react components.
-   *
-   * @param element
-   */
-  detachReact(element) {
-    if (element) {
-      ReactDOM.unmountComponentAtNode(element);
-    }
-  }
-
-  getValue() {
-    return this.dataValue;
-  }
-
-  setValue(value, flags = {}) {
-    this.dataForSetting = value;
-    if (this.reactElement) {
-      this.renderReact(this.reactElement);
-      this.shouldSetValue = false;
-    } else {
-      this.shouldSetValue = true;
-    }
-    return super.setValue(value, flags);
-  }
-
-  checkValidity(data, dirty, rowData) {
-    return super.checkValidity(data, dirty, rowData);
   }
 }

--- a/packages/shared-components/src/customComponents/components/NavDatepicker.jsx
+++ b/packages/shared-components/src/customComponents/components/NavDatepicker.jsx
@@ -44,8 +44,6 @@ function isCorrectOrder(beforeDate, afterDate, mayBeEqual = false) {
 
 export default class NavDatepicker extends FormioReactComponent {
   isValid = this.errors.length === 0;
-  reactElement = undefined;
-  input = null;
 
   /**
    * This function tells the form builder about your component. It's name, icon and what group it should be in.
@@ -177,8 +175,11 @@ export default class NavDatepicker extends FormioReactComponent {
     return result;
   }
 
-  static schema() {
-    return FormioReactComponent.schema(FormBuilderOptions.builder.datoOgTid.components.datoVelger.schema);
+  static schema(...extend) {
+    return FormioReactComponent.schema({
+      ...FormBuilderOptions.builder.datoOgTid.components.datoVelger.schema,
+      ...extend,
+    });
   }
 
   /*
@@ -333,54 +334,4 @@ export default class NavDatepicker extends FormioReactComponent {
       element
     );
   }
-
-  focus() {
-    if (this.input) {
-      this.input.focus();
-    }
-  }
-
-  attachReact(element) {
-    this.reactElement = element;
-    this.renderReact(element);
-    return this.reactElement;
-  }
-
-  detachReact(element) {
-    if (element) {
-      ReactDOM.unmountComponentAtNode(element);
-    }
-  }
-
-  getValue() {
-    return this.dataValue;
-  }
-
-  setValue(value, flag = {}) {
-    this.dataForSetting = value;
-    if (this.reactElement) {
-      this.renderReact(this.reactElement);
-      this.shouldSetValue = false;
-    } else {
-      this.shouldSetValue = true;
-    }
-    return super.setValue(value, flag);
-  }
-
-  checkValidity(data, dirty, rowData) {
-    const isValid = super.checkValidity(data, dirty, rowData);
-    this.componentIsValid(isValid);
-
-    if (!isValid) {
-      return false;
-    }
-    return this.validate(data, dirty, rowData);
-  }
-
-  componentIsValid = (isValid) => {
-    if (isValid !== this.isValid) {
-      this.isValid = !this.isValid;
-      this.renderReact(this.reactElement);
-    }
-  };
 }


### PR DESCRIPTION
This makes sure all React components will have fixes for initializing with submission, and behave the same. After testing, it seems to work quite well.
The goal is also that it should require as little as possible to create a new component.