### PR TITLE
bugfix export global translations

### DIFF
--- a/packages/bygger/src/translations/global/utils.test.ts
+++ b/packages/bygger/src/translations/global/utils.test.ts
@@ -271,5 +271,56 @@ describe("getGlobalTranslationsWithLanguageAndTag", () => {
         { key: "se", label: "SE" },
       ]);
     });
+
+    it("removes linebreaks before export", () => {
+      const globalTranslationLineBreaks = {
+        en: [
+          {
+            tag: "skjematekster",
+            translations: {
+              "<p>Test linjeskift linux\nwindows\r\napple\r</p>": {
+                value: "<p>Test Line break linux\nwindows\r\napple\r</p>",
+                scope: "global",
+              },
+            },
+          },
+        ],
+      };
+      const { data, headers } = transformGlobalTranslationsToCsvData(globalTranslationLineBreaks, [], "en");
+      expect(data).toEqual([
+        { text: "<p>Test linjeskift linux windows apple </p>", en: "<p>Test Line break linux windows apple </p>" },
+      ]);
+      expect(headers).toEqual([
+        { key: "text", label: "Globale tekster" },
+        { key: "en", label: "EN" },
+      ]);
+    });
+
+    it("escapes quotes", () => {
+      const globalTranslationLineBreaks = {
+        en: [
+          {
+            tag: "skjematekster",
+            translations: {
+              "<p>Lenke til <a href='https://www.nav.no/fyllut'>FyllUt</a></p>": {
+                value: '<p>Link to <a href="https://www.nav.no/fyllut">FyllUt</a></p>',
+                scope: "global",
+              },
+            },
+          },
+        ],
+      };
+      const { data, headers } = transformGlobalTranslationsToCsvData(globalTranslationLineBreaks, [], "en");
+      expect(data).toEqual([
+        {
+          text: '<p>Lenke til <a href="https://www.nav.no/fyllut">FyllUt</a></p>',
+          en: '<p>Link to <a href="https://www.nav.no/fyllut">FyllUt</a></p>',
+        },
+      ]);
+      expect(headers).toEqual([
+        { key: "text", label: "Globale tekster" },
+        { key: "en", label: "EN" },
+      ]);
+    });
   });
 });

--- a/packages/bygger/src/translations/global/utils.ts
+++ b/packages/bygger/src/translations/global/utils.ts
@@ -5,7 +5,7 @@ import {
   TEXTS,
   TranslationResource,
 } from "@navikt/skjemadigitalisering-shared-domain";
-import { getInputType, withoutDuplicatedComponents } from "../utils";
+import { escapeQuote, getInputType, removeLineBreaks, withoutDuplicatedComponents } from "../utils";
 
 const tags = {
   SKJEMATEKSTER: "skjematekster",
@@ -91,6 +91,8 @@ const getGlobalTranslationsWithLanguageAndTag = (
   return translationsResourceWithSelectedLanguageAndTag;
 };
 
+const sanitize = (text?) => escapeQuote(removeLineBreaks(text));
+
 const transformGlobalTranslationsToCsvData = (
   allGlobalTranslations: FormioTranslationMap,
   allPredefinedOriginalTexts,
@@ -105,7 +107,10 @@ const transformGlobalTranslationsToCsvData = (
     }
   });
 
-  const data = Object.keys(translations).map((text) => ({ text, [languageCode]: translations[text].value }));
+  const data = Object.keys(translations).map((text) => ({
+    text: sanitize(text),
+    [languageCode]: sanitize(translations[text].value),
+  }));
   const headers = [
     { label: "Globale tekster", key: "text" },
     { label: languageCode?.toUpperCase(), key: languageCode },

--- a/packages/bygger/src/translations/utils.js
+++ b/packages/bygger/src/translations/utils.js
@@ -186,7 +186,7 @@ const removeLineBreaksFromTranslations = (translations) => {
 
 const escapeQuote = (text) => {
   if (typeof text === "string" && text.includes("'")) {
-    return text.replaceAll(/'/g, '"');
+    return text.replace(/'/g, '"');
   }
   return text;
 };
@@ -233,10 +233,12 @@ const getTextsAndTranslationsHeaders = (translations) => {
 };
 
 export {
+  escapeQuote,
   getTextsAndTranslationsForForm,
   getTextsAndTranslationsHeaders,
   getInputType,
   withoutDuplicatedComponents,
   getFormTexts,
+  removeLineBreaks,
   removeLineBreaksFromTranslations,
 };


### PR DESCRIPTION
remove linebreaks and replace single quotes with double for correct formatting of csv export content