### PR TITLE
Only give alert about changes if you have changes.

### DIFF
--- a/packages/bygger/src/Forms/FormPage.jsx
+++ b/packages/bygger/src/Forms/FormPage.jsx
@@ -28,8 +28,10 @@ export const FormPage = ({ loadForm, loadTranslations, onSave, onPublish, onUnpu
   }, [loadForm, formPath]);
 
   const onChange = (changedForm) => {
-    setHasUnsavedChanged(true);
-    setForm(changedForm);
+    if (JSON.stringify(changedForm) !== JSON.stringify(form)) {
+      setHasUnsavedChanged(true);
+      setForm(changedForm);
+    }
   };
 
   const saveFormAndResetIsUnsavedChanges = async (form) => {


### PR DESCRIPTION
Simple compare to see if there have been changes to form object. Without this, it set hasUnsavedChanged even if you just link clicks or fill inn the form and not on actual changes.