### PR TITLE
Keep the page when we recreate FormBuilder.

### DIFF
--- a/packages/bygger/src/Forms/FormPage.jsx
+++ b/packages/bygger/src/Forms/FormPage.jsx
@@ -28,10 +28,24 @@ export const FormPage = ({ loadForm, loadTranslations, onSave, onPublish, onUnpu
   }, [loadForm, formPath]);
 
   const onChange = (changedForm) => {
-    if (JSON.stringify(changedForm) !== JSON.stringify(form)) {
+    if (formHasChanged(form, changedForm)) {
       setHasUnsavedChanged(true);
       setForm(changedForm);
     }
+  };
+
+  const formHasChanged = (form, changedForm) => {
+    return JSON.stringify(removeIds(form.components)) !== JSON.stringify(removeIds(changedForm.components));
+  };
+
+  const removeIds = (components) => {
+    return components.map((component) => {
+      return {
+        ...component,
+        id: undefined,
+        components: component.components && removeIds(component.components),
+      };
+    });
   };
 
   const saveFormAndResetIsUnsavedChanges = async (form) => {

--- a/packages/bygger/src/components/NavFormBuilder.jsx
+++ b/packages/bygger/src/components/NavFormBuilder.jsx
@@ -56,12 +56,15 @@ class NavFormBuilder extends Component {
     this.props.onChange(cloneDeep(this.builder.instance.form));
   };
 
-  createBuilder = () => {
+  createBuilder = (page) => {
     this.builder = new formiojs.FormBuilder(
       this.element.current,
       cloneDeep(this.props.form),
       this.props.formBuilderOptions
     );
+    if (page) {
+      this.builder.instance.setPage(page);
+    }
     this.builderReady = this.builder.ready;
     this.builderReady.then(() => {
       this.builder.instance.on("change", this.handleChange);
@@ -81,8 +84,9 @@ class NavFormBuilder extends Component {
   };
 
   updateFormBuilder() {
+    const page = this.builder.instance.page;
     this.destroyBuilder();
-    this.createBuilder();
+    this.createBuilder(page);
   }
 
   componentDidMount = () => {


### PR DESCRIPTION
Remove id's when checking if form has changed.