### PR TITLE
Fix translation of HTML and Alertstripe components

### DIFF
--- a/packages/shared-components/src/formio-overrides/utils-overrides.js
+++ b/packages/shared-components/src/formio-overrides/utils-overrides.js
@@ -5,6 +5,21 @@ Formio.Utils.toggleClass = (id, className) => {
   return `document.getElementById('${id}').classList.toggle('${className}')`;
 };
 
+/*
+ * This function is overridden because FormioUtils.sanitize calls dompurify.sanitize, which has a bug.
+ * The bug is discussed here: https://github.com/cure53/DOMPurify/issues/276
+ * In short, it reverses the order of attributes on HTML elements.
+ *
+ * For us, this breaks translations, as the text to be translated no longer matches the text in the translation file.
+ *
+ * By calling the sanitize-function twice, we reverse the reversed order, causing the original, correct order.
+ * This is messy, but we consider it safer than turning off sanitizing by sending in "sanitize = false" to NavForm.
+ */
+const originalSanitize = Utils.sanitize;
+Formio.Utils.sanitize = (string, options) => {
+  return originalSanitize(originalSanitize(string, options), options);
+};
+
 const originalEvaluate = Utils.evaluate;
 
 function evaluateOverride(func, args, ret, tokenize) {


### PR DESCRIPTION
Override FormioUtils.santize to run twice, to counteract a bug where attributes on HTML fields are consistently reversed.
The bug fixed by this commit caused translations of HTML code to fail, as the original text didn't match the one being translated.