### PR TITLE
Container legend was not translated in the template.

### DIFF
--- a/packages/shared-components/src/template/templates/navdesign/container/form.ejs
+++ b/packages/shared-components/src/template/templates/navdesign/container/form.ejs
@@ -5,7 +5,7 @@
 {% } else { %}
 <fieldset class="skjemagruppe">
  <legend class="skjemagruppe__legend" id="l-{{ctx.instance.id}}-{{ctx.component.key}}">
-   {{ctx.component.label}}
+   {{ctx.t(ctx.component.label)}}
  </legend>
   <div ref="{{ctx.nestedKey}}">{{ctx.children}}</div>
 </fieldset>


### PR DESCRIPTION
It was added to translations, but just not used.