### PR TITLE
Temporary fix for issue with scrolling to errorsList on change events after errorsList is shown.

### DIFF
--- a/packages/shared-components/src/Forms/FillInFormPage.jsx
+++ b/packages/shared-components/src/Forms/FillInFormPage.jsx
@@ -81,7 +81,8 @@ export const FillInFormPage = ({ form, submission, setSubmission, formUrl }) => 
 
   const onError = () => {
     loggSkjemaValideringFeilet();
-    scrollToAndSetFocus("div[id^='error-list-'] li:first-of-type");
+    // Commenting out as temporary fix for issue where we scroll to errorsList when onChange is triggered
+    //scrollToAndSetFocus("div[id^='error-list-'] li:first-of-type");
   };
 
   return (

--- a/packages/shared-components/src/template/templates/navdesign/errorsList/form.ejs
+++ b/packages/shared-components/src/template/templates/navdesign/errorsList/form.ejs
@@ -1,0 +1,19 @@
+<p tabindex="-1" autofocus>{{ctx.t('error')}}
+  {% if (ctx.options.vpat) { %}
+  <span ref="errorTooltip" class="{{ctx.iconClass('question-sign')}}" tabindex="0"></span>
+  {% } %}
+</p>
+<ul>
+  {% ctx.errors.forEach(function(err) { %}
+  <li>
+    <span
+      data-component-key = "{{err.keyOrPath}}"
+      ref = "errorRef"
+      tabIndex = "0"
+      role="link"
+    >
+      {{err.message}}
+    </span>
+  </li>
+  {% }) %}
+</ul>

--- a/packages/shared-components/src/template/templates/navdesign/errorsList/index.js
+++ b/packages/shared-components/src/template/templates/navdesign/errorsList/index.js
@@ -1,0 +1,3 @@
+import form from "./form.ejs";
+
+export default { form };

--- a/packages/shared-components/src/template/templates/navdesign/index.js
+++ b/packages/shared-components/src/template/templates/navdesign/index.js
@@ -20,6 +20,7 @@ import datagrid from "./datagrid";
 import day from "./day";
 import dialog from "./dialog";
 import editgrid from "./editgrid";
+import errorsList from "./errorsList";
 import field from "./field";
 import fieldset from "./fieldset";
 import file from "./file";
@@ -94,6 +95,7 @@ export default {
   day,
   dialog,
   editgrid,
+  errorsList,
   field,
   fieldset,
   file,


### PR DESCRIPTION
Should find a better alternative that does scroll on "click Neste"