### PR TITLE
Filtering supported enhetstyper (cleanup)

### DIFF
--- a/packages/shared-components/src/Forms/PrepareLetterPage.jsx
+++ b/packages/shared-components/src/Forms/PrepareLetterPage.jsx
@@ -203,7 +203,7 @@ export function PrepareLetterPage({ form, submission, formUrl, translations }) {
           const filteredList = enhetsliste.filter(isEnhetSupported(enhetstyper)).sort(compareEnheter);
           if (filteredList.length === 0) {
             setEnhetslisteFilteringError(true);
-            return enhetsliste.filter(isEnhetSupported()).sort(compareEnheter);
+            return enhetsliste.sort(compareEnheter);
           }
           return filteredList;
         })

--- a/packages/shared-components/src/Forms/PrepareLetterPage.test.jsx
+++ b/packages/shared-components/src/Forms/PrepareLetterPage.test.jsx
@@ -35,28 +35,13 @@ const RESPONSE_HEADERS_ERROR = {
   status: 500,
 };
 
-const enhetWithUnsupportedEnhetNr = {
-  enhetId: 0,
-  navn: "NAV-ENHET Ekskluderes pga enhetNr",
-  type: "KO",
-  enhetNr: "0000",
-};
-const enhetWithUnsupportedEnhetstype = {
-  enhetId: 1000,
-  navn: "NAV-ENHET Ekskluderes pga type",
-  type: "IKKE_STOTTET_ENHETSTYPE",
-  enhetNr: "1000",
-};
 const mockEnhetsListe = [
   { enhetId: 1, navn: "NAV-ENHET YTA", type: "YTA", enhetNr: "001" },
   { enhetId: 2, navn: "NAV-ENHET LOKAL", type: "LOKAL", enhetNr: "002" },
   { enhetId: 3, navn: "NAV-ENHET ARK", type: "ARK", enhetNr: "003" },
   { enhetId: 4, navn: "NAV-ENHET FPY", type: "FPY", enhetNr: "004" },
   { enhetId: 5, navn: "NAV-ENHET INTRO", type: "INTRO", enhetNr: "005" },
-  { enhetId: 6, navn: "NAV-ENHET FORVALTNING", type: "FORVALTNING", enhetNr: "006" },
-  { enhetId: 7, navn: "NAV-ENHET ALS", type: "ALS", enhetNr: "007" },
-  enhetWithUnsupportedEnhetNr,
-  enhetWithUnsupportedEnhetstype,
+  { enhetId: 6, navn: "NAV-ENHET ALS", type: "ALS", enhetNr: "006" },
 ];
 
 const defaultForm = {
@@ -186,6 +171,7 @@ describe("PrepareLetterPage", () => {
         fireEvent.keyDown(enhetSelector, DOWN_ARROW);
 
         const options = screen.getAllByText(/^NAV-ENHET/).map((element) => element.textContent);
+        expect(options).toHaveLength(3);
         expect(options).toEqual(["NAV-ENHET ALS", "NAV-ENHET ARK", "NAV-ENHET LOKAL"]);
       });
     });
@@ -276,8 +262,6 @@ describe("PrepareLetterPage", () => {
 
         const enhetSelectList = screen.getAllByText(/^NAV-ENHET/);
         expect(enhetSelectList).toHaveLength(6);
-        expect(screen.queryByText(enhetWithUnsupportedEnhetNr.navn)).toBeNull();
-        expect(screen.queryByText(enhetWithUnsupportedEnhetstype.navn)).toBeNull();
       }
     );
   });

--- a/packages/shared-components/src/api/fetchEnhetsliste.ts
+++ b/packages/shared-components/src/api/fetchEnhetsliste.ts
@@ -1,11 +1,9 @@
-import { Enhet, Enhetstype, supportedEnhetstyper } from "@navikt/skjemadigitalisering-shared-domain";
+import { Enhet, Enhetstype } from "@navikt/skjemadigitalisering-shared-domain";
 
-// TODO filtreringen er flyttet til Fyllut backend; bruk av "supportedEnhetstyper" samt sjekk på enhetNr "0000" skal fjernes fra denne filen.
-export const isEnhetSupported = (selectedEnhetstyper?: Enhetstype[]) => {
-  const enhetstyperToInclude =
-    Array.isArray(selectedEnhetstyper) && selectedEnhetstyper.length > 0 ? selectedEnhetstyper : supportedEnhetstyper;
+const notEmptyArray = (arr) => Array.isArray(arr) && arr.length > 0;
 
-  return (enhet: Enhet) => enhetstyperToInclude.includes(enhet.type) && enhet.enhetNr !== "0000";
+export const isEnhetSupported = (selectedEnhetstyper: Enhetstype[]) => {
+  return (enhet: Enhet) => (notEmptyArray(selectedEnhetstyper) ? selectedEnhetstyper.includes(enhet.type) : true);
 };
 
 export async function fetchEnhetsliste(baseUrl = ""): Promise<Enhet[]> {


### PR DESCRIPTION
Remove filtering of unsupported enhetstyper in frontend since this now happens in backend. Will still filter if form settings provides a list of valid enhetstyper.