### PR TITLE
Prevent undefined being rendered in PDF

### DIFF
--- a/packages/fyllut/server/src/routers/api/helpers/htmlBuilder.ts
+++ b/packages/fyllut/server/src/routers/api/helpers/htmlBuilder.ts
@@ -131,7 +131,7 @@ ${component.value.map((val) => `<div class="svar">: ${val}</div>`).join("")}`;
 
 const signature = ({ label, description, key }: NewFormSignatureType, translate: TranslateFunction) => `
 <h3>${translate(label)}</h3>
-<div class="underskrift">${translate(description)}</div>
+<div class="underskrift">${description ? translate(description) : ""}</div>
 <div class="underskrift">${translate(TEXTS.pdfStatiske.placeAndDate)} _________________________________________</div>
 <div class="underskrift">${translate(TEXTS.pdfStatiske.signature)} _________________________________________</div>`;
 


### PR DESCRIPTION
[Trello](https://trello.com/c/UadlngQ0/1400-undefined-i-pdf-fra-fyllut)

If description was `undefined` it would show `undefined` in the PDF. 

## DoD
Undefined is not shown in PDF  