### PR TITLE
Simplify form creation screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ til google cloud) og hente ut miljøvariabler fra podden, f.eks slik:
 
 I byggeren logger vi inn med [Azure AD](https://doc.nais.io/security/auth/azure-ad/sidecar/), bortsett fra under
 utvikling på lokal maskin, hvor utviklerene logger inn
-med [Formio-brukere](https://help.form.io/userguide/user-authentication).
+med [Formio-brukere](https://help.form.io/userguide/user-authentication). Se [oppretting av bruker](#opprette-formio-bruker-for-lokal-utvikling).
 
 I Azure AD er det opprettet grupper for tilgangsstyring til ulike funksjoner i applikasjonen. Gruppene har prefiks
 "Skjemabygging", og kan søkes fram på Microsofts
@@ -142,6 +142,11 @@ _Eierene_ av gruppene kan legge til nye medlemmer.
 En oversikt over gruppenes id'er vil dessuten ligge i koden for bygger backend såfremt de faktisk er i bruk:
 
 -   [azureAd.ts](https://github.com/navikt/skjemabygging-formio/tree/master/packages/bygger/server/src/middleware/azureAd.ts)
+
+### Opprette Formio-bruker for lokal utvikling
+
+-   Logg inn på https://formio-api.intern.dev.nav.no med brukernavn og passord fra Google Secrets
+-   Velg `Nav Skjemabase` -> `User` -> `Use` og skriv inn ønsket brukernavn/passord
 
 ### Fyllut
 

--- a/packages/bygger/cypress/e2e/settings.spec.cy.ts
+++ b/packages/bygger/cypress/e2e/settings.spec.cy.ts
@@ -29,6 +29,7 @@ describe("FormSettingsPage", () => {
       expect(req.body.properties.skjemanummer).to.include(_submitData.skjemanummer);
       expect(req.body.properties.descriptionOfSignatures).to.include(_submitData.descriptionOfSignatures);
       expect(req.body.properties.innsending).to.include(_submitData.innsending);
+      expect(req.body.properties.ettersending).to.include(_submitData.ettersending);
       expect(req.body.properties.signatures[0].label).to.include(_submitData.signatureLabel);
       expect(req.body.properties.signatures[0].description).to.include(_submitData.signatureDescription);
       req.reply(req.body);

--- a/packages/bygger/cypress/fixtures/getForm.json
+++ b/packages/bygger/cypress/fixtures/getForm.json
@@ -288,6 +288,7 @@
       "skjemanummer": "cypress-innstillinger",
       "tema": "CYPRESSTEST",
       "innsending": "PAPIR_OG_DIGITAL",
+      "ettersending": "PAPIR_OG_DIGITAL",
       "signatures": [
         { "label": "Lege", "description": "Instruksjoner fra lege...", "key": "5b2366f2-ed4f-4172-b89a-42202de00f2f" }
       ],

--- a/packages/bygger/src/Forms/FormSettingsPage.jsx
+++ b/packages/bygger/src/Forms/FormSettingsPage.jsx
@@ -19,16 +19,7 @@ const useStyles = makeStyles({
   },
 });
 
-export function FormSettingsPage({
-  form,
-  publishedForm,
-  onSave,
-  onChange,
-  onPublish,
-  onUnpublish,
-  visSkjemaMeny,
-  validateAndSave,
-}) {
+export function FormSettingsPage({ form, publishedForm, onSave, onChange, onPublish, onUnpublish, validateAndSave }) {
   const title = form.title;
   const [openPublishSettingModal, setOpenPublishSettingModal] = useModal(false);
   const styles = useStyles();

--- a/packages/bygger/src/Forms/FormSettingsPage.jsx
+++ b/packages/bygger/src/Forms/FormSettingsPage.jsx
@@ -35,7 +35,7 @@ export function FormSettingsPage({
   const [errors, setErrors] = useState({});
 
   validateAndSave = async (form) => {
-    const updatedErrors = validateFormMetadata(form);
+    const updatedErrors = validateFormMetadata(form, "edit");
     if (isFormMetadataValid(updatedErrors)) {
       setErrors({});
       return await onSave(form);

--- a/packages/bygger/src/Forms/NewFormPage.test.tsx
+++ b/packages/bygger/src/Forms/NewFormPage.test.tsx
@@ -1,4 +1,5 @@
 import { AppConfigProvider } from "@navikt/skjemadigitalisering-shared-components";
+import { NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "jest-fetch-mock";
@@ -46,6 +47,7 @@ describe("NewFormPage", () => {
     userEvent.click(screen.getByRole("button", { name: "Opprett" }));
 
     expect(saveForm).toHaveBeenCalledTimes(1);
+    // @ts-ignore
     const savedForm = saveForm.mock.calls[0][0] as NavFormType;
     expect(savedForm).toMatchObject({
       type: "form",

--- a/packages/bygger/src/Forms/NewFormPage.test.tsx
+++ b/packages/bygger/src/Forms/NewFormPage.test.tsx
@@ -46,8 +46,7 @@ describe("NewFormPage", () => {
     userEvent.click(screen.getByRole("button", { name: "Opprett" }));
 
     expect(saveForm).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    const savedForm = saveForm.mock.calls[0][0];
+    const savedForm = saveForm.mock.calls[0][0] as NavFormType;
     expect(savedForm).toMatchObject({
       type: "form",
       path: "nav102030",

--- a/packages/bygger/src/Forms/NewFormPage.test.tsx
+++ b/packages/bygger/src/Forms/NewFormPage.test.tsx
@@ -19,10 +19,11 @@ const mockTemaKoder = { ABC: "Tema 1", XYZ: "Tema 3", DEF: "Tema 2" };
 describe("NewFormPage", () => {
   beforeEach(() => {
     fetchMock.mockImplementation((url) => {
-      if (url.endsWith("/mottaksadresse/submission")) {
+      const stringUrl = url as string;
+      if (stringUrl.endsWith("/mottaksadresse/submission")) {
         return Promise.resolve(new Response(JSON.stringify(mockMottaksadresser), RESPONSE_HEADERS));
       }
-      if (url.endsWith("/temakoder")) {
+      if (stringUrl.endsWith("/temakoder")) {
         return Promise.resolve(new Response(JSON.stringify(mockTemaKoder), RESPONSE_HEADERS));
       }
       throw new Error(`Manglende testoppsett: Ukjent url ${url}`);
@@ -30,11 +31,10 @@ describe("NewFormPage", () => {
   });
   it("should create a new form with correct path, title and name", async () => {
     const saveForm = jest.fn(() => Promise.resolve(new Response(JSON.stringify({}))));
-    const onLogout = jest.fn();
     render(
       <MemoryRouter>
         <AppConfigProvider featureToggles={featureToggles}>
-          <NewFormPage formio={{ saveForm }} onLogout={onLogout} />
+          <NewFormPage formio={{ saveForm }} />
         </AppConfigProvider>
       </MemoryRouter>
     );
@@ -43,10 +43,10 @@ describe("NewFormPage", () => {
     userEvent.type(screen.getByLabelText("Skjemanummer"), "NAV 10-20.30 ");
     userEvent.type(screen.getByLabelText("Tittel"), "Et testskjema");
     userEvent.selectOptions(screen.getByLabelText("Tema"), "ABC");
-    userEvent.selectOptions(screen.getByLabelText("Ettersending"), "KUN_DIGITAL");
     userEvent.click(screen.getByRole("button", { name: "Opprett" }));
 
     expect(saveForm).toHaveBeenCalledTimes(1);
+    // @ts-ignore
     const savedForm = saveForm.mock.calls[0][0];
     expect(savedForm).toMatchObject({
       type: "form",
@@ -58,20 +58,17 @@ describe("NewFormPage", () => {
       properties: {
         skjemanummer: "NAV 10-20.30",
         tema: "ABC",
-        innsending: "PAPIR_OG_DIGITAL",
-        ettersending: "KUN_DIGITAL",
       },
     });
   });
   it("should handle exception from saveForm, with message to user", async () => {
     const saveForm = jest.fn(() => Promise.reject(new Error("Form.io feil")));
-    const onLogout = jest.fn();
     console.error = jest.fn();
     render(
       <FeedbackProvider>
         <MemoryRouter>
           <AppConfigProvider featureToggles={featureToggles}>
-            <NewFormPage formio={{ saveForm }} onLogout={onLogout} />
+            <NewFormPage formio={{ saveForm }} />
           </AppConfigProvider>
         </MemoryRouter>
       </FeedbackProvider>
@@ -81,7 +78,6 @@ describe("NewFormPage", () => {
     userEvent.type(screen.getByLabelText("Skjemanummer"), "NAV 10-20.30 ");
     userEvent.type(screen.getByLabelText("Tittel"), "Et testskjema");
     userEvent.selectOptions(screen.getByLabelText("Tema"), "ABC");
-    userEvent.selectOptions(screen.getByLabelText("Ettersending"), "KUN_DIGITAL");
     userEvent.click(screen.getByRole("button", { name: "Opprett" }));
 
     expect(saveForm).toHaveBeenCalledTimes(1);

--- a/packages/bygger/src/Forms/NewFormPage.tsx
+++ b/packages/bygger/src/Forms/NewFormPage.tsx
@@ -63,7 +63,7 @@ const NewFormPage: React.FC<Props> = ({ formio }): React.ReactElement => {
     });
   };
   const validateAndSave = async (form) => {
-    const updatedErrors = validateFormMetadata(form);
+    const updatedErrors = validateFormMetadata(form, "create");
     const trimmedFormNumber = state.form.properties.skjemanummer.trim();
     if (isFormMetadataValid(updatedErrors)) {
       setErrors({});

--- a/packages/bygger/src/Forms/NewFormPage.tsx
+++ b/packages/bygger/src/Forms/NewFormPage.tsx
@@ -44,6 +44,7 @@ const NewFormPage: React.FC<Props> = ({ formio }): React.ReactElement => {
         skjemanummer: "",
         tema: "",
         innsending: "PAPIR_OG_DIGITAL",
+        ettersending: "PAPIR_OG_DIGITAL",
         signatures: [{ label: "", description: "", key: uuidv4() }],
       },
       components: defaultFormFields() as unknown as Component[],

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.test.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.test.tsx
@@ -248,10 +248,10 @@ describe("FormMetadataEditor", () => {
           expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
         });
 
-        it("Vises ikke når innsending=undefined", async () => {
+        it("Vises når innsending=undefined", async () => {
           const form: NavFormType = formMedProps({ innsending: undefined });
           render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
         });
 
         it("Viser valgt mottaksadresse med formattering", async () => {

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.test.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.test.tsx
@@ -36,6 +36,38 @@ jest.mock("react-router-dom", () => ({
   Link: () => <a href="/">testlink</a>,
 }));
 
+const defaultForm: NavFormType = {
+  title: "Testskjema",
+  name: "testskjema",
+  path: "tst123456",
+  tags: ["nav-skjema", ""],
+  type: "form",
+  components: [],
+  properties: {
+    skjemanummer: "TST 12.34-56",
+    innsending: "PAPIR_OG_DIGITAL",
+    tema: "BIL",
+    enhetMaVelgesVedPapirInnsending: false,
+    enhetstyper: [],
+    signatures: [
+      {
+        label: "",
+        description: "",
+        key: "ddade517-86c6-4f1e-b730-a477e01dc245",
+      },
+    ],
+  },
+  display: "wizard",
+};
+
+const formMedProps = (props: Partial<FormPropertiesType>): NavFormType => ({
+  ...defaultForm,
+  properties: {
+    ...defaultForm.properties,
+    ...props,
+  },
+});
+
 describe("FormMetadataEditor", () => {
   let mockOnChange: jest.MockedFunction<UpdateFormFunction>;
 
@@ -78,29 +110,10 @@ describe("FormMetadataEditor", () => {
       );
       expect(screen.getByRole("textbox", { name: /Tittel/i })).toHaveValue("Søknad om førerhund");
     });
-  });
-
-  describe("Usage context: CREATE", () => {
-    const defaultForm: NavFormType = {
-      title: "Testskjema",
-      name: "testskjema",
-      path: "tst123456",
-      tags: ["nav-skjema", ""],
-      type: "form",
-      components: [],
-      properties: {
-        skjemanummer: "TST 12.34-56",
-        innsending: undefined,
-        tema: "BIL",
-        enhetMaVelgesVedPapirInnsending: false,
-        enhetstyper: [],
-      },
-      display: "wizard",
-    };
 
     describe("Forklaring til innsending", () => {
       it("Viser input for forklaring når innsending settes til INGEN", async () => {
-        const { rerender } = render(<CreationFormMetadataEditor form={defaultForm} onChange={mockOnChange} />);
+        const { rerender } = render(<FormMetadataEditor form={defaultForm} onChange={mockOnChange} />);
         expect(screen.queryByLabelText("Forklaring til innsending")).toBeNull();
         userEvent.selectOptions(screen.getByLabelText("Innsending"), "INGEN");
 
@@ -108,7 +121,7 @@ describe("FormMetadataEditor", () => {
         const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
         expect(updatedForm.properties.innsending).toEqual("INGEN");
 
-        rerender(<CreationFormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
+        rerender(<FormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
         expect(screen.queryByLabelText("Forklaring til innsending")).not.toBeNull();
       });
 
@@ -120,7 +133,7 @@ describe("FormMetadataEditor", () => {
             innsending: "INGEN",
           },
         };
-        const { rerender } = render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+        const { rerender } = render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
         expect(screen.queryByLabelText("Forklaring til innsending")).not.toBeNull();
         userEvent.selectOptions(screen.getByLabelText("Innsending"), "KUN_PAPIR");
 
@@ -128,7 +141,7 @@ describe("FormMetadataEditor", () => {
         const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
         expect(updatedForm.properties.innsending).toEqual("KUN_PAPIR");
 
-        rerender(<CreationFormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
+        rerender(<FormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
         expect(screen.queryByLabelText("Forklaring til innsending")).toBeNull();
       });
     });
@@ -141,7 +154,7 @@ describe("FormMetadataEditor", () => {
           innsending: "PAPIR_OG_DIGITAL",
         },
       };
-      const { rerender } = render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+      const { rerender } = render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
       expect(screen.queryByLabelText("Forklaring til innsending")).toBeNull();
       userEvent.selectOptions(screen.getByLabelText("Innsending"), "KUN_PAPIR");
 
@@ -149,7 +162,7 @@ describe("FormMetadataEditor", () => {
       const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
       expect(updatedForm.properties.innsending).toEqual("KUN_PAPIR");
 
-      rerender(<CreationFormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
+      rerender(<FormMetadataEditor form={updatedForm} onChange={mockOnChange} />);
       expect(screen.queryByLabelText("Forklaring til innsending")).toBeNull();
     });
 
@@ -164,7 +177,7 @@ describe("FormMetadataEditor", () => {
 
       it("lagres i properties", async () => {
         const form = formMedDownloadPdfButtonText(undefined);
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
         const input = screen.getByLabelText("Tekst på knapp for nedlasting av pdf");
         await userEvent.paste(input, "Last ned pdf");
 
@@ -175,7 +188,7 @@ describe("FormMetadataEditor", () => {
 
       it("nullstilles i properties", async () => {
         const form = formMedDownloadPdfButtonText("Last meg ned");
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
         const input = screen.getByLabelText("Tekst på knapp for nedlasting av pdf");
         await userEvent.clear(input);
 
@@ -184,20 +197,11 @@ describe("FormMetadataEditor", () => {
         expect(updatedForm.properties.downloadPdfButtonText).toEqual("");
       });
     });
-
-    const formMedProps = (props: Partial<FormPropertiesType>): NavFormType => ({
-      ...defaultForm,
-      properties: {
-        ...defaultForm.properties,
-        ...props,
-      },
-    });
-
     describe("Ettersendelsesfrist", () => {
       it("lagres i properties", async () => {
         const form = formMedProps({ ettersendelsesfrist: undefined, ettersending: "KUN_DIGITAL" });
 
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
         const input = screen.getByLabelText("Ettersendelsesfrist (dager)");
         await userEvent.paste(input, "42");
 
@@ -208,7 +212,7 @@ describe("FormMetadataEditor", () => {
 
       it("nullstilles i properties", async () => {
         const form = formMedProps({ ettersendelsesfrist: "42", ettersending: "KUN_DIGITAL" });
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
         const input = screen.getByLabelText("Ettersendelsesfrist (dager)");
         await userEvent.clear(input);
 
@@ -218,6 +222,312 @@ describe("FormMetadataEditor", () => {
       });
     });
 
+    describe("Mottaksadresse", () => {
+      describe("Dropdown med mottaksadresser", () => {
+        it("Vises ikke når innsending=INGEN", async () => {
+          const form: NavFormType = formMedProps({ innsending: "INGEN" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
+        });
+
+        it("Vises ikke når innsending=KUN_DIGITAL", async () => {
+          const form: NavFormType = formMedProps({ innsending: "KUN_DIGITAL" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
+        });
+
+        it("Vises når innsending=KUN_PAPIR", async () => {
+          const form: NavFormType = formMedProps({ innsending: "KUN_PAPIR" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
+        });
+
+        it("Vises når innsending=PAPIR_OG_DIGITAL", async () => {
+          const form: NavFormType = formMedProps({ innsending: "PAPIR_OG_DIGITAL" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
+        });
+
+        it("Vises ikke når innsending=undefined", async () => {
+          const form: NavFormType = formMedProps({ innsending: undefined });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
+        });
+
+        it("Viser valgt mottaksadresse med formattering", async () => {
+          const form: NavFormType = formMedProps({ mottaksadresseId: "1" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          expect(screen.getByDisplayValue("NAV alternativ skanning, Postboks 3, 0591 Oslo")).toBeTruthy();
+        });
+      });
+
+      describe("Endring av mottaksadresse", () => {
+        it("Setter ny mottaksadresse", async () => {
+          const form: NavFormType = formMedProps({ mottaksadresseId: undefined });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "1");
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+          const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+          expect(updatedForm.properties.mottaksadresseId).toEqual("1");
+        });
+
+        it("Fjerner valgt mottaksadresse", async () => {
+          const form: NavFormType = formMedProps({ mottaksadresseId: "1" });
+          render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+          userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "");
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+          const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+          expect(updatedForm.properties.mottaksadresseId).toBeUndefined();
+        });
+      });
+    });
+
+    describe("Innstilling for valg av enhet ved papirinnsending", () => {
+      const expectedCheckboxName = "Bruker må velge enhet ved innsending på papir";
+      const editFormMetadataEditor = (form: NavFormType, onChange: UpdateFormFunction) => (
+        <AppConfigProvider featureToggles={{ ...featureToggles, enableEnhetsListe: true }}>
+          <FormMetadataEditor form={form} onChange={onChange} />
+        </AppConfigProvider>
+      );
+
+      it("Vises når innsending=KUN_PAPIR", async () => {
+        const form: NavFormType = formMedProps({
+          innsending: "KUN_PAPIR",
+          mottaksadresseId: undefined,
+        });
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeTruthy();
+      });
+
+      it("Vises når innsending=PAPIR_OG_DIGITAL", async () => {
+        const form: NavFormType = formMedProps({ innsending: "PAPIR_OG_DIGITAL" });
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeTruthy();
+      });
+
+      it("Vises ikke når innsending=INGEN", async () => {
+        const form: NavFormType = formMedProps({ innsending: "INGEN" });
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
+      });
+
+      it("Vises ikke når innsending=KUN_DIGITAL", async () => {
+        const form: NavFormType = formMedProps({ innsending: "KUN_DIGITAL" });
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
+      });
+
+      it("Kan endres til true ved klikk på checkbox", () => {
+        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: false });
+        const { rerender } = render(editFormMetadataEditor(form, mockOnChange));
+        let checkbox = screen.getByRole("checkbox", {
+          name: expectedCheckboxName,
+        });
+        expect(checkbox).not.toBeChecked();
+        userEvent.click(checkbox);
+
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(true);
+
+        rerender(editFormMetadataEditor(updatedForm, mockOnChange));
+        checkbox = screen.getByRole("checkbox", {
+          name: expectedCheckboxName,
+        });
+        expect(checkbox).toBeChecked();
+      });
+
+      it("Kan endres til false ved klikk på checkbox", () => {
+        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: true });
+        const { rerender } = render(editFormMetadataEditor(form, mockOnChange));
+        let checkbox = screen.getByRole("checkbox", {
+          name: expectedCheckboxName,
+        });
+        expect(checkbox).toBeChecked();
+        userEvent.click(checkbox);
+
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(false);
+
+        rerender(editFormMetadataEditor(updatedForm, mockOnChange));
+        checkbox = screen.getByRole("checkbox", {
+          name: expectedCheckboxName,
+        });
+        expect(checkbox).not.toBeChecked();
+      });
+
+      it("huker av checkboxer for valgte enhetstyper", () => {
+        const form: NavFormType = formMedProps({
+          mottaksadresseId: undefined,
+          enhetMaVelgesVedPapirInnsending: true,
+          enhetstyper: ["ALS", "KO", "LOKAL"],
+        });
+        render(editFormMetadataEditor(form, mockOnChange));
+        const checkboxes = screen.getAllByRole("checkbox", { checked: true });
+        expect(checkboxes).toHaveLength(4);
+      });
+
+      it("fjerner valgt enhet ved klikk", () => {
+        const form: NavFormType = formMedProps({
+          mottaksadresseId: undefined,
+          enhetMaVelgesVedPapirInnsending: true,
+          enhetstyper: ["ALS", "KO", "LOKAL"],
+        });
+        render(editFormMetadataEditor(form, mockOnChange));
+        userEvent.click(screen.getByRole("checkbox", { name: "LOKAL" }));
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.enhetstyper).toEqual(["ALS", "KO"]);
+      });
+
+      it("legger til ny valgt enhet ved klikk", () => {
+        const form: NavFormType = formMedProps({
+          mottaksadresseId: undefined,
+          enhetMaVelgesVedPapirInnsending: true,
+          enhetstyper: ["ALS", "KO", "LOKAL"],
+        });
+        render(editFormMetadataEditor(form, mockOnChange));
+        userEvent.click(screen.getByRole("checkbox", { name: "ARK" }));
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.enhetstyper).toEqual(["ALS", "KO", "LOKAL", "ARK"]);
+      });
+
+      it("oppdaterer skjemaet med alle støttede enheter hvis enhetstyper er undefined", () => {
+        const props = {
+          mottaksadresseId: undefined,
+          enhetMaVelgesVedPapirInnsending: true,
+          enhetstyper: undefined,
+        };
+        const form: NavFormType = formMedProps(props);
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        expect(mockOnChange).toHaveBeenCalledWith(formMedProps({ ...props, enhetstyper: supportedEnhetstyper }));
+      });
+
+      it("Nullstilles og skjules når mottaksadresse velges", () => {
+        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: true });
+        const { rerender } = render(editFormMetadataEditor(form, mockOnChange));
+        userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "1");
+
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.mottaksadresseId).toEqual("1");
+        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(false);
+
+        rerender(editFormMetadataEditor(updatedForm, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
+      });
+
+      it("Er skjult når mottaksadresse er valgt", () => {
+        const form: NavFormType = formMedProps({ mottaksadresseId: "1", enhetMaVelgesVedPapirInnsending: true });
+        render(editFormMetadataEditor(form, mockOnChange));
+        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
+      });
+    });
+
+    describe("Signaturer", () => {
+      let form: NavFormType;
+      beforeEach(() => {
+        form = formMedProps({});
+      });
+
+      it("Legger til signatur", () => {
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+
+        const signaturFieldsets = screen.getAllByTestId("signatures");
+        expect(signaturFieldsets).toHaveLength(1);
+
+        const input = within(signaturFieldsets[0]).getByLabelText("Hvem skal signere?");
+        userEvent.paste(input, "Lege");
+
+        expect(mockOnChange).toHaveBeenCalled();
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+
+        expect(updatedForm.properties.signatures?.[0].label).toEqual("Lege");
+      });
+
+      it("legger til ny signatur ved klikk på 'legg til signatur' knapp", () => {
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+
+        const knapp = screen.getByRole("button", { name: "Legg til signatur" });
+        userEvent.click(knapp);
+
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.signatures?.[0].label).toEqual("");
+        expect(updatedForm.properties.signatures?.[0].description).toEqual("");
+      });
+
+      it("Slett en signatur", () => {
+        const multipleSignatures = [
+          {
+            label: "Doctor",
+            description: "Doctor Description",
+            key: "0",
+          },
+          {
+            label: "Test",
+            description: "Test Description",
+            key: "1",
+          },
+          {
+            label: "Applicant",
+            description: "Applicant Description",
+            key: "2",
+          },
+        ];
+
+        form = formMedProps({ signatures: multipleSignatures });
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+
+        const signaturFieldsets = screen.getAllByTestId("signatures");
+        expect(signaturFieldsets).toHaveLength(3);
+        const lukkKnapp = screen.getByRole("button", { name: "Slett signatur 2" });
+        userEvent.click(lukkKnapp);
+
+        expect(mockOnChange).toHaveBeenCalled();
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+
+        expect(updatedForm.properties.signatures?.[0].label).toEqual("Doctor");
+        expect(updatedForm.properties.signatures?.[0].description).toEqual("Doctor Description");
+        expect(updatedForm.properties.signatures?.[1].label).toEqual("Applicant");
+        expect(updatedForm.properties.signatures?.[1].description).toEqual("Applicant Description");
+      });
+
+      it("Legger til beskrivelse for en signatur", () => {
+        form = formMedProps({ signatures: [{ label: "Lege", key: "0000" }] });
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+
+        const signature1Description = screen.getAllByRole("textbox", { name: "Instruksjoner til den som signerer" })[0];
+        userEvent.paste(signature1Description, "Jeg bekrefter at personen er syk");
+
+        expect(mockOnChange).toHaveBeenCalled();
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.signatures?.[0].description).toEqual("Jeg bekrefter at personen er syk");
+        expect(updatedForm.properties.signatures?.[0].label).toEqual("Lege");
+      });
+    });
+
+    describe("Beskrivelse av alle signaturene", () => {
+      it("settes i properties når tekst legges inn i tekstfelt", () => {
+        const form: NavFormType = formMedProps({ signatures: [{ label: "Lege", key: uuidv4() }] });
+        render(<FormMetadataEditor form={form} onChange={mockOnChange} />);
+
+        const input = screen.getByLabelText("Generelle instruksjoner (valgfritt)");
+        userEvent.paste(input, "Lang beskrivelse av hvorfor man signerer");
+
+        expect(mockOnChange).toHaveBeenCalled();
+        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
+        expect(updatedForm.properties.descriptionOfSignatures).toEqual("Lang beskrivelse av hvorfor man signerer");
+      });
+    });
+  });
+
+  describe("Usage context: CREATE", () => {
     describe("Tema", () => {
       it("lister ut temaer", () => {
         render(<CreationFormMetadataEditor form={defaultForm} onChange={mockOnChange} />);
@@ -249,310 +559,6 @@ describe("FormMetadataEditor", () => {
         expect(mockOnChange).toHaveBeenCalledTimes(1);
         const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
         expect(updatedForm.properties.tema).toEqual("XYZ");
-      });
-    });
-
-    describe("Mottaksadresse", () => {
-      describe("Dropdown med mottaksadresser", () => {
-        it("Vises ikke når innsending=INGEN", async () => {
-          const form: NavFormType = formMedProps({ innsending: "INGEN" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
-        });
-
-        it("Vises ikke når innsending=KUN_DIGITAL", async () => {
-          const form: NavFormType = formMedProps({ innsending: "KUN_DIGITAL" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeFalsy();
-        });
-
-        it("Vises når innsending=KUN_PAPIR", async () => {
-          const form: NavFormType = formMedProps({ innsending: "KUN_PAPIR" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
-        });
-
-        it("Vises når innsending=PAPIR_OG_DIGITAL", async () => {
-          const form: NavFormType = formMedProps({ innsending: "PAPIR_OG_DIGITAL" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
-        });
-
-        it("Vises når innsending=undefined", async () => {
-          const form: NavFormType = formMedProps({ innsending: undefined });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.queryByLabelText("Mottaksadresse")).toBeTruthy();
-        });
-
-        it("Viser valgt mottaksadresse med formattering", async () => {
-          const form: NavFormType = formMedProps({ mottaksadresseId: "1" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          expect(screen.getByDisplayValue("NAV alternativ skanning, Postboks 3, 0591 Oslo")).toBeTruthy();
-        });
-      });
-
-      describe("Endring av mottaksadresse", () => {
-        it("Setter ny mottaksadresse", async () => {
-          const form: NavFormType = formMedProps({ mottaksadresseId: undefined });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "1");
-
-          expect(mockOnChange).toHaveBeenCalledTimes(1);
-          const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-          expect(updatedForm.properties.mottaksadresseId).toEqual("1");
-        });
-
-        it("Fjerner valgt mottaksadresse", async () => {
-          const form: NavFormType = formMedProps({ mottaksadresseId: "1" });
-          render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-          userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "");
-
-          expect(mockOnChange).toHaveBeenCalledTimes(1);
-          const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-          expect(updatedForm.properties.mottaksadresseId).toBeUndefined();
-        });
-      });
-    });
-
-    describe("Innstilling for valg av enhet ved papirinnsending", () => {
-      const expectedCheckboxName = "Bruker må velge enhet ved innsending på papir";
-      const creationFormMetadataEditor = (form, onChange) => (
-        <AppConfigProvider featureToggles={{ ...featureToggles, enableEnhetsListe: true }}>
-          <CreationFormMetadataEditor form={form} onChange={onChange} />
-        </AppConfigProvider>
-      );
-
-      it("Vises når innsending=KUN_PAPIR", async () => {
-        const form: NavFormType = formMedProps({
-          innsending: "KUN_PAPIR",
-          mottaksadresseId: undefined,
-        });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeTruthy();
-      });
-
-      it("Vises når innsending=PAPIR_OG_DIGITAL", async () => {
-        const form: NavFormType = formMedProps({ innsending: "PAPIR_OG_DIGITAL" });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeTruthy();
-      });
-
-      it("Vises ikke når innsending=INGEN", async () => {
-        const form: NavFormType = formMedProps({ innsending: "INGEN" });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
-      });
-
-      it("Vises ikke når innsending=KUN_DIGITAL", async () => {
-        const form: NavFormType = formMedProps({ innsending: "KUN_DIGITAL" });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
-      });
-
-      it("Kan endres til true ved klikk på checkbox", () => {
-        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: false });
-        const { rerender } = render(creationFormMetadataEditor(form, mockOnChange));
-        let checkbox = screen.getByRole("checkbox", {
-          name: expectedCheckboxName,
-        });
-        expect(checkbox).not.toBeChecked();
-        userEvent.click(checkbox);
-
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(true);
-
-        rerender(creationFormMetadataEditor(updatedForm, mockOnChange));
-        checkbox = screen.getByRole("checkbox", {
-          name: expectedCheckboxName,
-        });
-        expect(checkbox).toBeChecked();
-      });
-
-      it("Kan endres til false ved klikk på checkbox", () => {
-        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: true });
-        const { rerender } = render(creationFormMetadataEditor(form, mockOnChange));
-        let checkbox = screen.getByRole("checkbox", {
-          name: expectedCheckboxName,
-        });
-        expect(checkbox).toBeChecked();
-        userEvent.click(checkbox);
-
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(false);
-
-        rerender(creationFormMetadataEditor(updatedForm, mockOnChange));
-        checkbox = screen.getByRole("checkbox", {
-          name: expectedCheckboxName,
-        });
-        expect(checkbox).not.toBeChecked();
-      });
-
-      it("huker av checkboxer for valgte enhetstyper", () => {
-        const form: NavFormType = formMedProps({
-          mottaksadresseId: undefined,
-          enhetMaVelgesVedPapirInnsending: true,
-          enhetstyper: ["ALS", "KO", "LOKAL"],
-        });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        const checkboxes = screen.getAllByRole("checkbox", { checked: true });
-        expect(checkboxes).toHaveLength(4);
-      });
-
-      it("fjerner valgt enhet ved klikk", () => {
-        const form: NavFormType = formMedProps({
-          mottaksadresseId: undefined,
-          enhetMaVelgesVedPapirInnsending: true,
-          enhetstyper: ["ALS", "KO", "LOKAL"],
-        });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        userEvent.click(screen.getByRole("checkbox", { name: "LOKAL" }));
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.enhetstyper).toEqual(["ALS", "KO"]);
-      });
-
-      it("legger til ny valgt enhet ved klikk", () => {
-        const form: NavFormType = formMedProps({
-          mottaksadresseId: undefined,
-          enhetMaVelgesVedPapirInnsending: true,
-          enhetstyper: ["ALS", "KO", "LOKAL"],
-        });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        userEvent.click(screen.getByRole("checkbox", { name: "ARK" }));
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.enhetstyper).toEqual(["ALS", "KO", "LOKAL", "ARK"]);
-      });
-
-      it("oppdaterer skjemaet med alle støttede enheter hvis enhetstyper er undefined", () => {
-        const props = {
-          mottaksadresseId: undefined,
-          enhetMaVelgesVedPapirInnsending: true,
-          enhetstyper: undefined,
-        };
-        const form: NavFormType = formMedProps(props);
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        expect(mockOnChange).toHaveBeenCalledWith(formMedProps({ ...props, enhetstyper: supportedEnhetstyper }));
-      });
-
-      it("Nullstilles og skjules når mottaksadresse velges", () => {
-        const form: NavFormType = formMedProps({ mottaksadresseId: undefined, enhetMaVelgesVedPapirInnsending: true });
-        const { rerender } = render(creationFormMetadataEditor(form, mockOnChange));
-        userEvent.selectOptions(screen.getByLabelText("Mottaksadresse"), "1");
-
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.mottaksadresseId).toEqual("1");
-        expect(updatedForm.properties.enhetMaVelgesVedPapirInnsending).toBe(false);
-
-        rerender(creationFormMetadataEditor(updatedForm, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
-      });
-
-      it("Er skjult når mottaksadresse er valgt", () => {
-        const form: NavFormType = formMedProps({ mottaksadresseId: "1", enhetMaVelgesVedPapirInnsending: true });
-        render(creationFormMetadataEditor(form, mockOnChange));
-        expect(screen.queryByRole("checkbox", { name: expectedCheckboxName })).toBeFalsy();
-      });
-    });
-
-    describe("Signaturer", () => {
-      let form: NavFormType;
-      beforeEach(() => {
-        form = formMedProps({});
-      });
-
-      it("Legger til signatur", () => {
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-
-        const signaturFieldsets = screen.getAllByTestId("signatures");
-        expect(signaturFieldsets).toHaveLength(1);
-
-        const input = within(signaturFieldsets[0]).getByLabelText("Hvem skal signere?");
-        userEvent.paste(input, "Lege");
-
-        expect(mockOnChange).toHaveBeenCalled();
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-
-        expect(updatedForm.properties.signatures?.[0].label).toEqual("Lege");
-      });
-
-      it("legger til ny signatur ved klikk på 'legg til signatur' knapp", () => {
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-
-        const knapp = screen.getByRole("button", { name: "Legg til signatur" });
-        userEvent.click(knapp);
-
-        expect(mockOnChange).toHaveBeenCalledTimes(1);
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.signatures?.[0].label).toEqual("");
-        expect(updatedForm.properties.signatures?.[0].description).toEqual("");
-      });
-
-      it("Slett en signatur", () => {
-        const multipleSignatures = [
-          {
-            label: "Doctor",
-            description: "Doctor Description",
-            key: "0",
-          },
-          {
-            label: "Test",
-            description: "Test Description",
-            key: "1",
-          },
-          {
-            label: "Applicant",
-            description: "Applicant Description",
-            key: "2",
-          },
-        ];
-
-        form = formMedProps({ signatures: multipleSignatures });
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-
-        const signaturFieldsets = screen.getAllByTestId("signatures");
-        expect(signaturFieldsets).toHaveLength(3);
-        const lukkKnapp = screen.getByRole("button", { name: "Slett signatur 2" });
-        userEvent.click(lukkKnapp);
-
-        expect(mockOnChange).toHaveBeenCalled();
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-
-        expect(updatedForm.properties.signatures?.[0].label).toEqual("Doctor");
-        expect(updatedForm.properties.signatures?.[0].description).toEqual("Doctor Description");
-        expect(updatedForm.properties.signatures?.[1].label).toEqual("Applicant");
-        expect(updatedForm.properties.signatures?.[1].description).toEqual("Applicant Description");
-      });
-
-      it("Legger til beskrivelse for en signatur", () => {
-        form = formMedProps({ signatures: [{ label: "Lege", key: "0000" }] });
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-
-        const signature1Description = screen.getAllByRole("textbox", { name: "Instruksjoner til den som signerer" })[0];
-        userEvent.paste(signature1Description, "Jeg bekrefter at personen er syk");
-
-        expect(mockOnChange).toHaveBeenCalled();
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.signatures?.[0].description).toEqual("Jeg bekrefter at personen er syk");
-        expect(updatedForm.properties.signatures?.[0].label).toEqual("Lege");
-      });
-    });
-
-    describe("Beskrivelse av alle signaturene", () => {
-      it("settes i properties når tekst legges inn i tekstfelt", () => {
-        const form: NavFormType = formMedProps({ signatures: [{ label: "Lege", key: uuidv4() }] });
-        render(<CreationFormMetadataEditor form={form} onChange={mockOnChange} />);
-
-        const input = screen.getByLabelText("Generelle instruksjoner (valgfritt)");
-        userEvent.paste(input, "Lang beskrivelse av hvorfor man signerer");
-
-        expect(mockOnChange).toHaveBeenCalled();
-        const updatedForm = mockOnChange.mock.calls[0][0] as NavFormType;
-        expect(updatedForm.properties.descriptionOfSignatures).toEqual("Lang beskrivelse av hvorfor man signerer");
       });
     });
   });

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
@@ -55,7 +55,7 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
 
   const addressFields = () => <AddressFields onChange={onChange} diff={diff} form={form}></AddressFields>;
 
-  const enhetsListFields = () => <EnhetFields onChange={onChange} form={form}></EnhetFields>;
+  const enhetFields = () => <EnhetFields onChange={onChange} form={form}></EnhetFields>;
 
   const instructionFields = () => (
     <>
@@ -85,7 +85,7 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           {downloadPdfButtonTextFields()}
           {submissionFields()}
           {addressFields()}
-          {enhetsListFields()}
+          {enhetFields()}
           {instructionFields()}
           {signatureFields()}
         </>

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
@@ -1,24 +1,12 @@
-import { Copy } from "@navikt/ds-icons";
-import { Alert, Button, Checkbox, Fieldset, Select, Textarea, TextField, ToggleGroup } from "@navikt/ds-react";
-import { makeStyles, useAppConfig } from "@navikt/skjemadigitalisering-shared-components";
-import {
-  DeclarationType,
-  formDiffingTool,
-  InnsendingType,
-  MottaksadresseData,
-  NavFormType,
-  signatureUtils,
-  TEXTS,
-} from "@navikt/skjemadigitalisering-shared-domain";
-import { Link } from "react-router-dom";
-import { v4 as uuidv4 } from "uuid";
-import useMottaksadresser from "../../hooks/useMottaksadresser";
-import useTemaKoder from "../../hooks/useTemaKoder";
-import copy from "../../util/copy";
-import SignatureComponent from "../layout/SignatureComponent";
-import EnhetSettings from "./EnhetSettings";
+import { Alert, Fieldset, Textarea, TextField } from "@navikt/ds-react";
+import { formDiffingTool, NavFormType, TEXTS } from "@navikt/skjemadigitalisering-shared-domain";
+import AddressFields from "./fields/AddressFields";
+import BasicFields from "./fields/BasicFields";
+import DeclarationFields from "./fields/DeclarationFields";
+import EnhetFields from "./fields/EnhetFields";
+import SignatureFields from "./fields/SignatureFields";
+import SubmissionFields from "./fields/SubmissionFields";
 import LabelWithDiff from "./LabelWithDiff";
-import SubmissionTypeSelect from "./SubmissionTypeSelect";
 import { FormMetadataError, UpdateFormFunction } from "./utils";
 
 type UsageContext = "create" | "edit";
@@ -32,231 +20,18 @@ interface Props {
 
 type BasicFormProps = Props & { usageContext: UsageContext };
 
-const useStyles = makeStyles({
-  row: {
-    display: "flex",
-    justifyContent: "space-between",
-  },
-});
-
 const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, errors }: BasicFormProps) => {
-  const { featureToggles, config } = useAppConfig();
-  const { mottaksadresser, ready: isMottaksAdresserReady, errorMessage: mottaksadresseError } = useMottaksadresser();
-  const { temaKoder, ready: isTemaKoderReady, errorMessage: temaKoderError } = useTemaKoder();
   const diff = formDiffingTool.generateNavFormSettingsDiff(publishedForm, form);
-  const styles = useStyles();
   const {
-    title,
-    path,
-    properties: {
-      isTestForm,
-      skjemanummer,
-      tema,
-      downloadPdfButtonText,
-      innsending: innsendingFraProps,
-      ettersending,
-      ettersendelsesfrist,
-      mottaksadresseId,
-      declarationText,
-      enhetMaVelgesVedPapirInnsending,
-      enhetstyper,
-      descriptionOfSignatures,
-      descriptionOfSignaturesPositionUnder,
-      signatures,
-    },
+    properties: { downloadPdfButtonText, descriptionOfSignatures },
   } = form;
 
-  const addNewSignature = () =>
-    onChange({
-      ...form,
-      properties: {
-        ...form.properties,
-        signatures: [
-          ...signatureUtils.mapBackwardCompatibleSignatures(signatures),
-          {
-            label: "",
-            description: "",
-            key: uuidv4(),
-          },
-        ],
-      },
-    });
-
-  const addExistingSignature = (newSignature, index) =>
-    onChange({
-      ...form,
-      properties: {
-        ...form.properties,
-        signatures: signatureUtils.mapBackwardCompatibleSignatures(signatures).map((signatureObject, i) => {
-          if (index === i) {
-            return newSignature;
-          } else {
-            return signatureObject;
-          }
-        }),
-      },
-    });
-
-  const removeSignature = (signatureKey) => {
-    const mappedSignatures = signatureUtils.mapBackwardCompatibleSignatures(signatures);
-    if (mappedSignatures.length > 0) {
-      const updatedSignatures = mappedSignatures.filter((s) => s.key !== signatureKey);
-
-      onChange({
-        ...form,
-        properties: {
-          ...form.properties,
-          signatures: updatedSignatures,
-        },
-      });
-    }
-  };
-
-  const innsending = innsendingFraProps || "PAPIR_OG_DIGITAL";
-
-  const toAddressString = (address: MottaksadresseData) => {
-    const linjer = [address.adresselinje1];
-    if (address.adresselinje2) {
-      linjer.push(address.adresselinje2);
-    }
-    if (address.adresselinje3) {
-      linjer.push(address.adresselinje3);
-    }
-    return `${linjer.join(", ")}, ${address.postnummer} ${address.poststed}`;
-  };
-
   const basicFields = () => (
-    <>
-      {testSkjemaFields()}
-      <TextField
-        className="mb"
-        label="Skjemanummer"
-        type="text"
-        id="skjemanummer"
-        placeholder="Skriv inn skjemanummer"
-        value={skjemanummer}
-        readOnly={usageContext === "edit"}
-        onChange={(event) =>
-          onChange({ ...form, properties: { ...form.properties, skjemanummer: event.target.value } })
-        }
-        error={errors?.skjemanummer}
-      />
-      <TextField
-        className="mb"
-        label={<LabelWithDiff label="Tittel" diff={!!diff.title} />}
-        type="text"
-        id="title"
-        placeholder="Skriv inn tittel"
-        value={title}
-        onChange={(event) => onChange({ ...form, title: event.target.value })}
-        error={errors?.title}
-      />
-      {temaKodeFields()}
-    </>
+    <BasicFields onChange={onChange} diff={diff} form={form} errors={errors} usageContext={usageContext} />
   );
 
-  const testSkjemaFields = () => (
-    <>
-      <div className={`mb ${styles.row}`}>
-        <Checkbox
-          id="teststatus"
-          checked={!!isTestForm}
-          onChange={(event) =>
-            onChange({ ...form, properties: { ...form.properties, isTestForm: event.target.checked } })
-          }
-        >
-          Dette er et testskjema
-        </Checkbox>
-        <span>
-          Skjemadelingslenke
-          <Button
-            onClick={() => copy(`${config!.fyllutBaseUrl}/test/login?formPath=${path}`)}
-            icon={<Copy />}
-            title="Kopier skjemadelingslenke"
-            variant="tertiary"
-            size="xsmall"
-          />
-        </span>
-      </div>
-    </>
-  );
-
-  const temaKodeFields = () => (
-    <>
-      <Select
-        className="mb-4"
-        label={<LabelWithDiff label="Tema" diff={!!diff.tema} />}
-        id="tema"
-        disabled={!isTemaKoderReady}
-        value={temaKoder?.find((temaKode) => temaKode.key === tema)?.key || ""}
-        onChange={(event) => onChange({ ...form, properties: { ...form.properties, tema: event.target.value } })}
-        error={errors?.tema}
-      >
-        <option value="">{"Velg tema"}</option>
-        {temaKoder?.map(({ key, value }) => (
-          <option key={key} value={key}>
-            {`${value} (${key})`}
-          </option>
-        ))}
-      </Select>
-      {temaKoderError && (
-        <Alert variant="error" size="small">
-          {temaKoderError}
-        </Alert>
-      )}
-    </>
-  );
-
-  const summaryPageDeclarationFields = () => (
-    <>
-      <LabelWithDiff label="Erklæring på oppsummeringsside" diff={!!diff.declarationType} />
-      <div className="mb">
-        <ToggleGroup
-          size="small"
-          defaultValue={form.properties.declarationType ?? DeclarationType.none}
-          onChange={(value) => {
-            const declarationType = value as DeclarationType;
-            let properties;
-            if (declarationType !== DeclarationType.custom && form.properties.declarationText) {
-              properties = { ...form.properties, declarationType, declarationText: undefined };
-            } else {
-              properties = { ...form.properties, declarationType };
-            }
-
-            onChange({
-              ...form,
-              properties,
-            });
-          }}
-          className="mb-4"
-        >
-          <ToggleGroup.Item value={DeclarationType.none}>Ingen</ToggleGroup.Item>
-          <ToggleGroup.Item value={DeclarationType.default}>Standard</ToggleGroup.Item>
-          <ToggleGroup.Item value={DeclarationType.custom}>Tilpasset</ToggleGroup.Item>
-        </ToggleGroup>
-
-        {form.properties.declarationType === DeclarationType.custom && (
-          <Textarea
-            label={<LabelWithDiff label="Tilpasset erklæringstekst" diff={!!diff.declarationText} />}
-            value={declarationText || ""}
-            onChange={(event) =>
-              onChange({
-                ...form,
-                properties: { ...form.properties, declarationText: event.target.value },
-              })
-            }
-            error={errors?.declarationText}
-          />
-        )}
-
-        {form.properties.declarationType === DeclarationType.default && (
-          <div>
-            <label className="navds-label">Standard erklæringstekst</label>
-            <div>{TEXTS.statiske.declaration.defaultText}</div>
-          </div>
-        )}
-      </div>
-    </>
+  const declarationFields = () => (
+    <DeclarationFields onChange={onChange} diff={diff} form={form} errors={errors}></DeclarationFields>
   );
 
   const downloadPdfButtonTextFields = () => (
@@ -277,147 +52,12 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
   );
 
   const submissionFields = () => (
-    <>
-      <SubmissionTypeSelect
-        name="form-innsending"
-        label={<LabelWithDiff label="Innsending" diff={!!diff.innsending} />}
-        value={innsending}
-        onChange={(event) =>
-          onChange({
-            ...form,
-            properties: { ...form.properties, innsending: event.target.value as InnsendingType },
-          })
-        }
-      />
-      <SubmissionTypeSelect
-        name="form-ettersending"
-        label={<LabelWithDiff label="Ettersending" diff={!!diff.ettersending} />}
-        value={ettersending}
-        allowEmpty={true}
-        error={errors?.ettersending}
-        onChange={(event) =>
-          onChange({
-            ...form,
-            properties: { ...form.properties, ettersending: event.target.value as InnsendingType },
-          })
-        }
-      />
-      {!!ettersending && ettersending !== "INGEN" && (
-        <TextField
-          className="mb"
-          label={<LabelWithDiff label="Ettersendelsesfrist (dager)" diff={!!diff.ettersendelsesfrist} />}
-          type="number"
-          id="ettersendelsesfrist"
-          value={ettersendelsesfrist || ""}
-          onChange={(event) =>
-            onChange({
-              ...form,
-              properties: { ...form.properties, ettersendelsesfrist: event.target.value },
-            })
-          }
-          placeholder={"Standard (14 dager)"}
-        />
-      )}
-      {innsending === "INGEN" && (
-        <>
-          <TextField
-            className="mb"
-            label={<LabelWithDiff label="Overskrift til innsending" diff={!!diff.innsendingOverskrift} />}
-            value={form.properties.innsendingOverskrift || ""}
-            onChange={(event) =>
-              onChange({
-                ...form,
-                properties: { ...form.properties, innsendingOverskrift: event.target.value },
-              })
-            }
-          />
-          <Textarea
-            className="mb"
-            label={<LabelWithDiff label="Forklaring til innsending" diff={!!diff.innsendingForklaring} />}
-            value={form.properties.innsendingForklaring || ""}
-            onChange={(event) =>
-              onChange({
-                ...form,
-                properties: { ...form.properties, innsendingForklaring: event.target.value },
-              })
-            }
-          />
-        </>
-      )}
-    </>
+    <SubmissionFields onChange={onChange} diff={diff} form={form} errors={errors}></SubmissionFields>
   );
 
-  const addressFields = () => (
-    <>
-      {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") && (
-        <div>
-          <Select
-            className="mb-4"
-            label={<LabelWithDiff label="Mottaksadresse" diff={!!diff.mottaksadresseId} />}
-            name="form-mottaksadresse"
-            id="form-mottaksadresse"
-            value={mottaksadresseId}
-            disabled={!isMottaksAdresserReady}
-            onChange={(event) =>
-              onChange({
-                ...form,
-                properties: {
-                  ...form.properties,
-                  mottaksadresseId: event.target.value || undefined,
-                  enhetMaVelgesVedPapirInnsending: false,
-                },
-              })
-            }
-          >
-            <option value="">
-              {mottaksadresseId && !isMottaksAdresserReady ? `Mottaksadresse-id: ${mottaksadresseId}` : "Standard"}
-            </option>
-            {mottaksadresser.map((adresse) => (
-              <option value={adresse._id} key={adresse._id}>
-                {toAddressString(adresse.data)}
-              </option>
-            ))}
-          </Select>
-          {mottaksadresseError && (
-            <Alert variant="error" size="small">
-              {mottaksadresseError}
-            </Alert>
-          )}
-        </div>
-      )}
-      <div className="mb">
-        <Link to="/mottaksadresser">Rediger mottaksadresser</Link>
-      </div>
-    </>
-  );
+  const addressFields = () => <AddressFields onChange={onChange} diff={diff} form={form}></AddressFields>;
 
-  const enhetsListFields = () => (
-    <>
-      {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") &&
-        !mottaksadresseId &&
-        featureToggles?.enableEnhetsListe && (
-          <div className="mb">
-            <EnhetSettings
-              enhetMaVelges={!!enhetMaVelgesVedPapirInnsending}
-              selectedEnhetstyper={enhetstyper}
-              onChangeEnhetMaVelges={(selected) =>
-                onChange({
-                  ...form,
-                  properties: {
-                    ...form.properties,
-                    enhetMaVelgesVedPapirInnsending: selected,
-                    enhetstyper: selected ? form.properties.enhetstyper : undefined,
-                  },
-                })
-              }
-              onChangeEnhetstyper={(enhetstyper) =>
-                onChange({ ...form, properties: { ...form.properties, enhetstyper } })
-              }
-            />
-          </div>
-        )}
-    </>
-  );
+  const enhetsListFields = () => <EnhetFields onChange={onChange} form={form}></EnhetFields>;
 
   const instructionFields = () => (
     <>
@@ -435,36 +75,7 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
     </>
   );
 
-  const signatureFields = () => (
-    <>
-      <Checkbox
-        className="mb"
-        checked={!!descriptionOfSignaturesPositionUnder}
-        onChange={(event) =>
-          onChange({
-            ...form,
-            properties: { ...form.properties, descriptionOfSignaturesPositionUnder: event.target.checked },
-          })
-        }
-      >
-        Plasser under signaturer
-      </Checkbox>
-      {signatureUtils.mapBackwardCompatibleSignatures(signatures)?.map((signature, index) => (
-        <div key={signature.key}>
-          <SignatureComponent
-            signature={signature}
-            diff={diff.signatures?.[signature.key]}
-            index={index}
-            onChange={(newSignature) => addExistingSignature(newSignature, index)}
-            onDelete={() => removeSignature(signature.key)}
-          />
-        </div>
-      ))}
-      <Button variant="secondary" className="mb" onClick={addNewSignature}>
-        Legg til signatur
-      </Button>
-    </>
-  );
+  const signatureFields = () => <SignatureFields onChange={onChange} diff={diff} form={form} />;
 
   return (
     <Fieldset hideLegend legend="">
@@ -472,7 +83,7 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
       <div className="mb">{basicFields()}</div>
       {usageContext === "edit" && (
         <>
-          {summaryPageDeclarationFields()}
+          {declarationFields()}
           {downloadPdfButtonTextFields()}
           {submissionFields()}
           {addressFields()}

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
@@ -1,5 +1,5 @@
 import { Alert, Fieldset, Textarea, TextField } from "@navikt/ds-react";
-import { formDiffingTool, NavFormType, TEXTS } from "@navikt/skjemadigitalisering-shared-domain";
+import { formDiffingTool, NavFormType, TEXTS, UsageContext } from "@navikt/skjemadigitalisering-shared-domain";
 import AddressFields from "./fields/AddressFields";
 import BasicFields from "./fields/BasicFields";
 import DeclarationFields from "./fields/DeclarationFields";
@@ -8,8 +8,6 @@ import SignatureFields from "./fields/SignatureFields";
 import SubmissionFields from "./fields/SubmissionFields";
 import LabelWithDiff from "./LabelWithDiff";
 import { FormMetadataError, UpdateFormFunction } from "./utils";
-
-type UsageContext = "create" | "edit";
 
 interface Props {
   form: NavFormType;

--- a/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/FormMetadataEditor.tsx
@@ -125,30 +125,9 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
     return `${linjer.join(", ")}, ${address.postnummer} ${address.poststed}`;
   };
 
-  return (
-    <Fieldset hideLegend legend="">
-      {diff.errorMessage && <Alert variant="warning">{diff.errorMessage}</Alert>}
-      <div className={`mb ${styles.row}`}>
-        <Checkbox
-          id="teststatus"
-          checked={!!isTestForm}
-          onChange={(event) =>
-            onChange({ ...form, properties: { ...form.properties, isTestForm: event.target.checked } })
-          }
-        >
-          Dette er et testskjema
-        </Checkbox>
-        <span>
-          Skjemadelingslenke
-          <Button
-            onClick={() => copy(`${config!.fyllutBaseUrl}/test/login?formPath=${path}`)}
-            icon={<Copy />}
-            title="Kopier skjemadelingslenke"
-            variant="tertiary"
-            size="xsmall"
-          />
-        </span>
-      </div>
+  const basicFields = () => (
+    <>
+      {testSkjemaFields()}
       <TextField
         className="mb"
         label="Skjemanummer"
@@ -172,32 +151,65 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
         onChange={(event) => onChange({ ...form, title: event.target.value })}
         error={errors?.title}
       />
-      <div className="mb">
-        <Select
-          className="mb-4"
-          label={<LabelWithDiff label="Tema" diff={!!diff.tema} />}
-          id="tema"
-          disabled={!isTemaKoderReady}
-          value={temaKoder?.find((temaKode) => temaKode.key === tema)?.key || ""}
-          onChange={(event) => onChange({ ...form, properties: { ...form.properties, tema: event.target.value } })}
-          error={errors?.tema}
+      {temaKodeFields()}
+    </>
+  );
+
+  const testSkjemaFields = () => (
+    <>
+      <div className={`mb ${styles.row}`}>
+        <Checkbox
+          id="teststatus"
+          checked={!!isTestForm}
+          onChange={(event) =>
+            onChange({ ...form, properties: { ...form.properties, isTestForm: event.target.checked } })
+          }
         >
-          <option value="">{"Velg tema"}</option>
-          {temaKoder?.map(({ key, value }) => (
-            <option key={key} value={key}>
-              {`${value} (${key})`}
-            </option>
-          ))}
-        </Select>
-        {temaKoderError && (
-          <Alert variant="error" size="small">
-            {temaKoderError}
-          </Alert>
-        )}
+          Dette er et testskjema
+        </Checkbox>
+        <span>
+          Skjemadelingslenke
+          <Button
+            onClick={() => copy(`${config!.fyllutBaseUrl}/test/login?formPath=${path}`)}
+            icon={<Copy />}
+            title="Kopier skjemadelingslenke"
+            variant="tertiary"
+            size="xsmall"
+          />
+        </span>
       </div>
+    </>
+  );
 
+  const temaKodeFields = () => (
+    <>
+      <Select
+        className="mb-4"
+        label={<LabelWithDiff label="Tema" diff={!!diff.tema} />}
+        id="tema"
+        disabled={!isTemaKoderReady}
+        value={temaKoder?.find((temaKode) => temaKode.key === tema)?.key || ""}
+        onChange={(event) => onChange({ ...form, properties: { ...form.properties, tema: event.target.value } })}
+        error={errors?.tema}
+      >
+        <option value="">{"Velg tema"}</option>
+        {temaKoder?.map(({ key, value }) => (
+          <option key={key} value={key}>
+            {`${value} (${key})`}
+          </option>
+        ))}
+      </Select>
+      {temaKoderError && (
+        <Alert variant="error" size="small">
+          {temaKoderError}
+        </Alert>
+      )}
+    </>
+  );
+
+  const summaryPageDeclarationFields = () => (
+    <>
       <LabelWithDiff label="Erklæring på oppsummeringsside" diff={!!diff.declarationType} />
-
       <div className="mb">
         <ToggleGroup
           size="small"
@@ -244,22 +256,28 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           </div>
         )}
       </div>
+    </>
+  );
 
-      <TextField
-        className="mb"
-        label={<LabelWithDiff label="Tekst på knapp for nedlasting av pdf" diff={!!diff.downloadPdfButtonText} />}
-        type="text"
-        id="downloadPdfButtonText"
-        value={downloadPdfButtonText || ""}
-        onChange={(event) =>
-          onChange({
-            ...form,
-            properties: { ...form.properties, downloadPdfButtonText: event.target.value },
-          })
-        }
-        placeholder={TEXTS.grensesnitt.downloadApplication}
-      />
+  const downloadPdfButtonTextFields = () => (
+    <TextField
+      className="mb"
+      label={<LabelWithDiff label="Tekst på knapp for nedlasting av pdf" diff={!!diff.downloadPdfButtonText} />}
+      type="text"
+      id="downloadPdfButtonText"
+      value={downloadPdfButtonText || ""}
+      onChange={(event) =>
+        onChange({
+          ...form,
+          properties: { ...form.properties, downloadPdfButtonText: event.target.value },
+        })
+      }
+      placeholder={TEXTS.grensesnitt.downloadApplication}
+    />
+  );
 
+  const submissionFields = () => (
+    <>
       <SubmissionTypeSelect
         name="form-innsending"
         label={<LabelWithDiff label="Innsending" diff={!!diff.innsending} />}
@@ -300,7 +318,6 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           placeholder={"Standard (14 dager)"}
         />
       )}
-
       {innsending === "INGEN" && (
         <>
           <TextField
@@ -327,6 +344,11 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           />
         </>
       )}
+    </>
+  );
+
+  const addressFields = () => (
+    <>
       {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") && (
         <div>
           <Select
@@ -366,6 +388,11 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
       <div className="mb">
         <Link to="/mottaksadresser">Rediger mottaksadresser</Link>
       </div>
+    </>
+  );
+
+  const enhetsListFields = () => (
+    <>
       {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") &&
         !mottaksadresseId &&
         featureToggles?.enableEnhetsListe && (
@@ -389,7 +416,11 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
             />
           </div>
         )}
+    </>
+  );
 
+  const instructionFields = () => (
+    <>
       <Textarea
         label={<LabelWithDiff label="Generelle instruksjoner (valgfritt)" diff={!!diff.descriptionOfSignatures} />}
         value={descriptionOfSignatures || ""}
@@ -401,7 +432,11 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           })
         }
       />
+    </>
+  );
 
+  const signatureFields = () => (
+    <>
       <Checkbox
         className="mb"
         checked={!!descriptionOfSignaturesPositionUnder}
@@ -414,7 +449,6 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
       >
         Plasser under signaturer
       </Checkbox>
-
       {signatureUtils.mapBackwardCompatibleSignatures(signatures)?.map((signature, index) => (
         <div key={signature.key}>
           <SignatureComponent
@@ -426,10 +460,27 @@ const BasicFormMetadataEditor = ({ form, publishedForm, onChange, usageContext, 
           />
         </div>
       ))}
-
       <Button variant="secondary" className="mb" onClick={addNewSignature}>
         Legg til signatur
       </Button>
+    </>
+  );
+
+  return (
+    <Fieldset hideLegend legend="">
+      {diff.errorMessage && <Alert variant="warning">{diff.errorMessage}</Alert>}
+      <div className="mb">{basicFields()}</div>
+      {usageContext === "edit" && (
+        <>
+          {summaryPageDeclarationFields()}
+          {downloadPdfButtonTextFields()}
+          {submissionFields()}
+          {addressFields()}
+          {enhetsListFields()}
+          {instructionFields()}
+          {signatureFields()}
+        </>
+      )}
     </Fieldset>
   );
 };

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/AddressFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/AddressFields.tsx
@@ -12,7 +12,7 @@ export interface AddressFieldsProps {
 }
 
 const AddressFields = ({ onChange, diff, form }: AddressFieldsProps) => {
-  const innsending = form.properties.innsending;
+  const innsending = form.properties.innsending || "PAPIR_OG_DIGITAL";
   const mottaksadresseId = form.properties.mottaksadresseId;
   const { mottaksadresser, ready: isMottaksAdresserReady, errorMessage: mottaksadresseError } = useMottaksadresser();
 

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/AddressFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/AddressFields.tsx
@@ -1,0 +1,75 @@
+import { Alert, Select } from "@navikt/ds-react";
+import { MottaksadresseData, NavFormSettingsDiff, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import { Link } from "react-router-dom";
+import useMottaksadresser from "../../../hooks/useMottaksadresser";
+import LabelWithDiff from "../LabelWithDiff";
+import { UpdateFormFunction } from "../utils";
+
+export interface AddressFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+}
+
+const AddressFields = ({ onChange, diff, form }: AddressFieldsProps) => {
+  const innsending = form.properties.innsending;
+  const mottaksadresseId = form.properties.mottaksadresseId;
+  const { mottaksadresser, ready: isMottaksAdresserReady, errorMessage: mottaksadresseError } = useMottaksadresser();
+
+  const toAddressString = (address: MottaksadresseData) => {
+    const linjer = [address.adresselinje1];
+    if (address.adresselinje2) {
+      linjer.push(address.adresselinje2);
+    }
+    if (address.adresselinje3) {
+      linjer.push(address.adresselinje3);
+    }
+    return `${linjer.join(", ")}, ${address.postnummer} ${address.poststed}`;
+  };
+
+  return (
+    <>
+      {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") && (
+        <div>
+          <Select
+            className="mb-4"
+            label={<LabelWithDiff label="Mottaksadresse" diff={!!diff.mottaksadresseId} />}
+            name="form-mottaksadresse"
+            id="form-mottaksadresse"
+            value={mottaksadresseId}
+            disabled={!isMottaksAdresserReady}
+            onChange={(event) =>
+              onChange({
+                ...form,
+                properties: {
+                  ...form.properties,
+                  mottaksadresseId: event.target.value || undefined,
+                  enhetMaVelgesVedPapirInnsending: false,
+                },
+              })
+            }
+          >
+            <option value="">
+              {mottaksadresseId && !isMottaksAdresserReady ? `Mottaksadresse-id: ${mottaksadresseId}` : "Standard"}
+            </option>
+            {mottaksadresser.map((adresse) => (
+              <option value={adresse._id} key={adresse._id}>
+                {toAddressString(adresse.data)}
+              </option>
+            ))}
+          </Select>
+          {mottaksadresseError && (
+            <Alert variant="error" size="small">
+              {mottaksadresseError}
+            </Alert>
+          )}
+        </div>
+      )}
+      <div className="mb">
+        <Link to="/mottaksadresser">Rediger mottaksadresser</Link>
+      </div>
+    </>
+  );
+};
+
+export default AddressFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/BasicFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/BasicFields.tsx
@@ -1,5 +1,5 @@
 import { TextField } from "@navikt/ds-react";
-import { NavFormSettingsDiff, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import { NavFormSettingsDiff, NavFormType, UsageContext } from "@navikt/skjemadigitalisering-shared-domain";
 import LabelWithDiff from "../LabelWithDiff";
 import { FormMetadataError, UpdateFormFunction } from "../utils";
 import TemaKodeFields from "./TemaKodeFields";
@@ -10,7 +10,7 @@ export interface BasicFieldsProps {
   diff: NavFormSettingsDiff;
   form: NavFormType;
   errors?: FormMetadataError;
-  usageContext: "create" | "edit";
+  usageContext: UsageContext;
 }
 
 const BasicFields = ({ onChange, diff, form, errors, usageContext }: BasicFieldsProps) => {

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/BasicFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/BasicFields.tsx
@@ -1,0 +1,57 @@
+import { TextField } from "@navikt/ds-react";
+import { NavFormSettingsDiff, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import LabelWithDiff from "../LabelWithDiff";
+import { FormMetadataError, UpdateFormFunction } from "../utils";
+import TemaKodeFields from "./TemaKodeFields";
+import TestSkjemaFields from "./TestSkjemaFields";
+
+export interface BasicFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+  errors?: FormMetadataError;
+  usageContext: "create" | "edit";
+}
+
+const BasicFields = ({ onChange, diff, form, errors, usageContext }: BasicFieldsProps) => {
+  const skjemanummer = form.properties.skjemanummer;
+  const title = form.title;
+
+  const testSkjemaFields = () => <TestSkjemaFields onChange={onChange} form={form} />;
+
+  const temaKodeFields = () => (
+    <TemaKodeFields onChange={onChange} diff={diff} form={form} errors={errors}></TemaKodeFields>
+  );
+
+  return (
+    <>
+      {testSkjemaFields()}
+      <TextField
+        className="mb"
+        label="Skjemanummer"
+        type="text"
+        id="skjemanummer"
+        placeholder="Skriv inn skjemanummer"
+        value={skjemanummer}
+        readOnly={usageContext === "edit"}
+        onChange={(event) =>
+          onChange({ ...form, properties: { ...form.properties, skjemanummer: event.target.value } })
+        }
+        error={errors?.skjemanummer}
+      />
+      <TextField
+        className="mb"
+        label={<LabelWithDiff label="Tittel" diff={!!diff.title} />}
+        type="text"
+        id="title"
+        placeholder="Skriv inn tittel"
+        value={title}
+        onChange={(event) => onChange({ ...form, title: event.target.value })}
+        error={errors?.title}
+      />
+      {temaKodeFields()}
+    </>
+  );
+};
+
+export default BasicFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/DeclarationFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/DeclarationFields.tsx
@@ -1,0 +1,69 @@
+import { Textarea, ToggleGroup } from "@navikt/ds-react";
+import { DeclarationType, NavFormSettingsDiff, NavFormType, TEXTS } from "@navikt/skjemadigitalisering-shared-domain";
+import LabelWithDiff from "../LabelWithDiff";
+import { FormMetadataError, UpdateFormFunction } from "../utils";
+
+export interface DeclarationFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+  errors?: FormMetadataError;
+}
+
+const DeclarationFields = ({ onChange, diff, form, errors }: DeclarationFieldsProps) => {
+  const declarationText = form.properties.declarationText;
+
+  return (
+    <>
+      <LabelWithDiff label="Erklæring på oppsummeringsside" diff={!!diff.declarationType} />
+      <div className="mb">
+        <ToggleGroup
+          size="small"
+          defaultValue={form.properties.declarationType ?? DeclarationType.none}
+          onChange={(value) => {
+            const declarationType = value as DeclarationType;
+            let properties;
+            if (declarationType !== DeclarationType.custom && form.properties.declarationText) {
+              properties = { ...form.properties, declarationType, declarationText: undefined };
+            } else {
+              properties = { ...form.properties, declarationType };
+            }
+
+            onChange({
+              ...form,
+              properties,
+            });
+          }}
+          className="mb-4"
+        >
+          <ToggleGroup.Item value={DeclarationType.none}>Ingen</ToggleGroup.Item>
+          <ToggleGroup.Item value={DeclarationType.default}>Standard</ToggleGroup.Item>
+          <ToggleGroup.Item value={DeclarationType.custom}>Tilpasset</ToggleGroup.Item>
+        </ToggleGroup>
+
+        {form.properties.declarationType === DeclarationType.custom && (
+          <Textarea
+            label={<LabelWithDiff label="Tilpasset erklæringstekst" diff={!!diff.declarationText} />}
+            value={declarationText || ""}
+            onChange={(event) =>
+              onChange({
+                ...form,
+                properties: { ...form.properties, declarationText: event.target.value },
+              })
+            }
+            error={errors?.declarationText}
+          />
+        )}
+
+        {form.properties.declarationType === DeclarationType.default && (
+          <div>
+            <label className="navds-label">Standard erklæringstekst</label>
+            <div>{TEXTS.statiske.declaration.defaultText}</div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default DeclarationFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/EnhetFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/EnhetFields.tsx
@@ -1,0 +1,48 @@
+import { useAppConfig } from "@navikt/skjemadigitalisering-shared-components";
+import { NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import EnhetSettings from "../EnhetSettings";
+import { UpdateFormFunction } from "../utils";
+
+export interface EnhetFieldsProps {
+  onChange: UpdateFormFunction;
+  form: NavFormType;
+}
+
+const EnhetFields = ({ onChange, form }: EnhetFieldsProps) => {
+  const { featureToggles } = useAppConfig();
+
+  const innsending = form.properties.innsending || "PAPIR_OG_DIGITAL";
+  const mottaksadresseId = form.properties.mottaksadresseId;
+  const enhetMaVelgesVedPapirInnsending = form.properties.enhetMaVelgesVedPapirInnsending;
+  const enhetstyper = form.properties.enhetstyper;
+
+  return (
+    <>
+      {(innsending === "KUN_PAPIR" || innsending === "PAPIR_OG_DIGITAL") &&
+        !mottaksadresseId &&
+        featureToggles?.enableEnhetsListe && (
+          <div className="mb">
+            <EnhetSettings
+              enhetMaVelges={!!enhetMaVelgesVedPapirInnsending}
+              selectedEnhetstyper={enhetstyper}
+              onChangeEnhetMaVelges={(selected) =>
+                onChange({
+                  ...form,
+                  properties: {
+                    ...form.properties,
+                    enhetMaVelgesVedPapirInnsending: selected,
+                    enhetstyper: selected ? form.properties.enhetstyper : undefined,
+                  },
+                })
+              }
+              onChangeEnhetstyper={(enhetstyper) =>
+                onChange({ ...form, properties: { ...form.properties, enhetstyper } })
+              }
+            />
+          </div>
+        )}
+    </>
+  );
+};
+
+export default EnhetFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/SignatureFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/SignatureFields.tsx
@@ -1,0 +1,102 @@
+import { Button, Checkbox } from "@navikt/ds-react";
+import {
+  NavFormSettingsDiff,
+  NavFormType,
+  NewFormSignatureType,
+  signatureUtils,
+} from "@navikt/skjemadigitalisering-shared-domain";
+import { v4 as uuidv4 } from "uuid";
+import SignatureComponent from "../../layout/SignatureComponent";
+import { UpdateFormFunction } from "../utils";
+
+export interface SignatureFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+}
+
+const SignatureFields = ({ onChange, diff, form }: SignatureFieldsProps) => {
+  const signatures = form.properties.signatures || [];
+  const descriptionOfSignaturesPositionUnder = form.properties.descriptionOfSignaturesPositionUnder || false;
+
+  const addExistingSignature = (newSignature: NewFormSignatureType, index: number) =>
+    onChange({
+      ...form,
+      properties: {
+        ...form.properties,
+        signatures: signatureUtils.mapBackwardCompatibleSignatures(signatures).map((signatureObject, i) => {
+          if (index === i) {
+            return newSignature;
+          } else {
+            return signatureObject;
+          }
+        }),
+      },
+    });
+
+  const addNewSignature = () =>
+    onChange({
+      ...form,
+      properties: {
+        ...form.properties,
+        signatures: [
+          ...signatureUtils.mapBackwardCompatibleSignatures(signatures),
+          {
+            label: "",
+            description: "",
+            key: uuidv4(),
+          },
+        ],
+      },
+    });
+
+  const removeSignature = (signatureKey: string) => {
+    const mappedSignatures = signatureUtils.mapBackwardCompatibleSignatures(signatures);
+    if (mappedSignatures.length > 0) {
+      const updatedSignatures = mappedSignatures.filter((s) => s.key !== signatureKey);
+
+      onChange({
+        ...form,
+        properties: {
+          ...form.properties,
+          signatures: updatedSignatures,
+        },
+      });
+    }
+  };
+
+  return (
+    <>
+      <Checkbox
+        className="mb"
+        checked={!!descriptionOfSignaturesPositionUnder}
+        onChange={(event) =>
+          onChange({
+            ...form,
+            properties: { ...form.properties, descriptionOfSignaturesPositionUnder: event.target.checked },
+          })
+        }
+      >
+        Plasser under signaturer
+      </Checkbox>
+
+      {signatureUtils.mapBackwardCompatibleSignatures(signatures)?.map((signature, index) => (
+        <div key={signature.key}>
+          <SignatureComponent
+            signature={signature}
+            diff={diff.signatures?.[signature.key]}
+            index={index}
+            onChange={(newSignature) => addExistingSignature(newSignature, index)}
+            onDelete={() => removeSignature(signature.key)}
+          />
+        </div>
+      ))}
+
+      <Button variant="secondary" className="mb" onClick={addNewSignature}>
+        Legg til signatur
+      </Button>
+    </>
+  );
+};
+
+export default SignatureFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
@@ -13,7 +13,7 @@ export interface SubmissionFieldsProps {
 
 const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProps) => {
   const innsending = form.properties.innsending || "PAPIR_OG_DIGITAL";
-  const ettersending = form.properties.ettersending;
+  const ettersending = form.properties.ettersending || "PAPIR_OG_DIGITAL";
   const ettersendelsesfrist = form.properties.ettersendelsesfrist;
 
   return (

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
@@ -1,0 +1,94 @@
+import { TextField, Textarea } from "@navikt/ds-react";
+import { InnsendingType, NavFormSettingsDiff, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import LabelWithDiff from "../LabelWithDiff";
+import SubmissionTypeSelect from "../SubmissionTypeSelect";
+import { FormMetadataError, UpdateFormFunction } from "../utils";
+
+export interface SubmissionFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+  errors?: FormMetadataError;
+}
+
+const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProps) => {
+  const innsending = form.properties.innsending || "PAPIR_OG_DIGITAL";
+  const ettersending = form.properties.ettersending;
+  const ettersendelsesfrist = form.properties.ettersendelsesfrist;
+
+  return (
+    <>
+      <SubmissionTypeSelect
+        name="form-innsending"
+        label={<LabelWithDiff label="Innsending" diff={!!diff.innsending} />}
+        value={innsending}
+        onChange={(event) =>
+          onChange({
+            ...form,
+            properties: { ...form.properties, innsending: event.target.value as InnsendingType },
+          })
+        }
+      />
+
+      <SubmissionTypeSelect
+        name="form-ettersending"
+        label={<LabelWithDiff label="Ettersending" diff={!!diff.ettersending} />}
+        value={ettersending}
+        allowEmpty={true}
+        error={errors?.ettersending}
+        onChange={(event) =>
+          onChange({
+            ...form,
+            properties: { ...form.properties, ettersending: event.target.value as InnsendingType },
+          })
+        }
+      />
+
+      {!!ettersending && ettersending !== "INGEN" && (
+        <TextField
+          className="mb"
+          label={<LabelWithDiff label="Ettersendelsesfrist (dager)" diff={!!diff.ettersendelsesfrist} />}
+          type="number"
+          id="ettersendelsesfrist"
+          value={ettersendelsesfrist || ""}
+          onChange={(event) =>
+            onChange({
+              ...form,
+              properties: { ...form.properties, ettersendelsesfrist: event.target.value },
+            })
+          }
+          placeholder={"Standard (14 dager)"}
+        />
+      )}
+
+      {innsending === "INGEN" && (
+        <>
+          <TextField
+            className="mb"
+            label={<LabelWithDiff label="Overskrift til innsending" diff={!!diff.innsendingOverskrift} />}
+            value={form.properties.innsendingOverskrift || ""}
+            onChange={(event) =>
+              onChange({
+                ...form,
+                properties: { ...form.properties, innsendingOverskrift: event.target.value },
+              })
+            }
+          />
+          <Textarea
+            className="mb"
+            label={<LabelWithDiff label="Forklaring til innsending" diff={!!diff.innsendingForklaring} />}
+            value={form.properties.innsendingForklaring || ""}
+            onChange={(event) =>
+              onChange({
+                ...form,
+                properties: { ...form.properties, innsendingForklaring: event.target.value },
+              })
+            }
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default SubmissionFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/TemaKodeFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/TemaKodeFields.tsx
@@ -1,0 +1,45 @@
+import { Alert, Select } from "@navikt/ds-react";
+import { NavFormSettingsDiff, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import useTemaKoder from "../../../hooks/useTemaKoder";
+import LabelWithDiff from "../LabelWithDiff";
+import { FormMetadataError, UpdateFormFunction } from "../utils";
+
+export interface TemaKodeFieldsProps {
+  onChange: UpdateFormFunction;
+  diff: NavFormSettingsDiff;
+  form: NavFormType;
+  errors?: FormMetadataError;
+}
+
+const TemaKodeFields = ({ onChange, diff, form, errors }: TemaKodeFieldsProps) => {
+  const { temaKoder, ready: isTemaKoderReady, errorMessage: temaKoderError } = useTemaKoder();
+  const tema = form.properties.tema;
+
+  return (
+    <>
+      <Select
+        className="mb-4"
+        label={<LabelWithDiff label="Tema" diff={!!diff.tema} />}
+        id="tema"
+        disabled={!isTemaKoderReady}
+        value={temaKoder?.find((temaKode) => temaKode.key === tema)?.key || ""}
+        onChange={(event) => onChange({ ...form, properties: { ...form.properties, tema: event.target.value } })}
+        error={errors?.tema}
+      >
+        <option value="">{"Velg tema"}</option>
+        {temaKoder?.map(({ key, value }) => (
+          <option key={key} value={key}>
+            {`${value} (${key})`}
+          </option>
+        ))}
+      </Select>
+      {temaKoderError && (
+        <Alert variant="error" size="small">
+          {temaKoderError}
+        </Alert>
+      )}
+    </>
+  );
+};
+
+export default TemaKodeFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/TestSkjemaFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/TestSkjemaFields.tsx
@@ -1,0 +1,55 @@
+import { Button, Checkbox } from "@navikt/ds-react";
+import { NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import { UpdateFormFunction } from "../utils";
+
+import { Copy } from "@navikt/ds-icons";
+import { makeStyles, useAppConfig } from "@navikt/skjemadigitalisering-shared-components";
+import copy from "../../../util/copy";
+
+export interface TestSkjemaFieldsProps {
+  onChange: UpdateFormFunction;
+  form: NavFormType;
+}
+
+const useStyles = makeStyles({
+  row: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+});
+
+const TestSkjemaFields = ({ onChange, form }: TestSkjemaFieldsProps) => {
+  const isTestForm = form.properties.isTestForm;
+  const path = form.path;
+
+  const styles = useStyles();
+  const { config } = useAppConfig();
+
+  return (
+    <>
+      <div className={`mb ${styles.row}`}>
+        <Checkbox
+          id="teststatus"
+          checked={!!isTestForm}
+          onChange={(event) =>
+            onChange({ ...form, properties: { ...form.properties, isTestForm: event.target.checked } })
+          }
+        >
+          Dette er et testskjema
+        </Checkbox>
+        <span>
+          Skjemadelingslenke
+          <Button
+            onClick={() => copy(`${config!.fyllutBaseUrl}/test/login?formPath=${path}`)}
+            icon={<Copy />}
+            title="Kopier skjemadelingslenke"
+            variant="tertiary"
+            size="xsmall"
+          />
+        </span>
+      </div>
+    </>
+  );
+};
+
+export default TestSkjemaFields;

--- a/packages/bygger/src/components/FormMetaDataEditor/utils.ts
+++ b/packages/bygger/src/components/FormMetaDataEditor/utils.ts
@@ -1,9 +1,9 @@
-import { DeclarationType, NavFormType } from "@navikt/skjemadigitalisering-shared-domain";
+import { DeclarationType, NavFormType, UsageContext } from "@navikt/skjemadigitalisering-shared-domain";
 
 export type UpdateFormFunction = (form: NavFormType) => void;
 export type FormMetadataError = { [key: string]: string };
 
-export const validateFormMetadata = (form: NavFormType) => {
+export const validateFormMetadata = (form: NavFormType, usageContext: UsageContext) => {
   const errors = {} as FormMetadataError;
   if (!form.title) {
     errors.title = "Du må oppgi skjematittel";
@@ -14,12 +14,17 @@ export const validateFormMetadata = (form: NavFormType) => {
   if (!form.properties.tema) {
     errors.tema = "Du må velge ett tema";
   }
-  if (!form.properties.ettersending) {
-    errors.ettersending = "Du må velge innsendingstype for ettersending";
+
+  // Some fields are only required in edit mode
+  if (usageContext === "edit") {
+    if (!form.properties.ettersending) {
+      errors.ettersending = "Du må velge innsendingstype for ettersending";
+    }
+    if (form.properties.declarationType === DeclarationType.custom && !form.properties.declarationText) {
+      errors.declarationText = "Du må lage en tilpasset erklæringstekst";
+    }
   }
-  if (form.properties.declarationType === DeclarationType.custom && !form.properties.declarationText) {
-    errors.declarationText = "Du må lage en tilpasset erklæringstekst";
-  }
+
   return errors;
 };
 

--- a/packages/shared-domain/src/form/index.ts
+++ b/packages/shared-domain/src/form/index.ts
@@ -158,3 +158,5 @@ export interface Submission {
   };
   state: string;
 }
+
+export type UsageContext = "create" | "edit";

--- a/packages/shared-domain/src/index.ts
+++ b/packages/shared-domain/src/index.ts
@@ -11,6 +11,7 @@ import {
   NewFormSignatureType,
   Panel,
   Submission,
+  UsageContext,
 } from "./form";
 import { ForstesideRequestBody, KjentBruker, UkjentBruker } from "./forsteside";
 import languagesUtil from "./languages/languagesUtil";
@@ -110,4 +111,5 @@ export type {
   ReportDefinition,
   Operator,
   NavFormSettingsDiff,
+  UsageContext,
 };

--- a/packages/shared-domain/src/index.ts
+++ b/packages/shared-domain/src/index.ts
@@ -39,7 +39,7 @@ import MockedComponentObjectForTest from "./summary/MockedComponentObjectForTest
 import TEXTS from "./texts";
 import dateUtils from "./utils/date";
 import featureUtils, { FeatureTogglesMap } from "./utils/featureUtils";
-import formDiffingTool from "./utils/formDiffingTool";
+import formDiffingTool, { NavFormSettingsDiff } from "./utils/formDiffingTool";
 import navFormioUtils from "./utils/formio";
 import { guid } from "./utils/guid";
 import localizationUtils from "./utils/localization";
@@ -109,4 +109,5 @@ export type {
   UkjentBruker,
   ReportDefinition,
   Operator,
+  NavFormSettingsDiff,
 };

--- a/packages/shared-domain/src/utils/formDiffingTool.ts
+++ b/packages/shared-domain/src/utils/formDiffingTool.ts
@@ -70,7 +70,7 @@ const toSignaturesDiff = (arrayDiff: any): SignaturesDiff | undefined => {
   return diff;
 };
 
-type NavFormSettingsDiff = {
+export type NavFormSettingsDiff = {
   [key in keyof FormPropertiesType]?: object;
 } & { errorMessage?: string; title?: string };
 const generateNavFormSettingsDiff = (


### PR DESCRIPTION
[Trello](https://trello.com/c/iJcVHtqE/1398-fjerne-felt-fra-opprett-skjema-skjema)

## Description
The creation screen should only contain these fields: 
- Skjemanummer
- Tittel
- Tema
- Testskjema (checkbox)

Refactored all the fields in the form into separate components and now show fields based on the `usageContext` (create | edit) 
Also updated readme regarding login to the bygger locally. 

The simplified creation screen: 
![Skjermbilde 2023-08-04 kl  10 37 35](https://github.com/navikt/skjemabygging-formio/assets/7783861/4358d567-3586-4a89-bc8c-df1086c72003)

