### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 20
     groups:
-      aksel:
+      navikt:
         patterns:
           - "@navikt/*"
       all-minor-patch:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: increase
+    open-pull-requests-limit: 20
+    groups:
+      aksel:
+        patterns:
+          - "@navikt/*"
+      all-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "formiojs"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
According to this: https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027, it should work in a monorepo by using the root directory `/` and `versioning-strategy: increase`, but needs to be tested