### PR TITLE
Fix problem with trying to populate country translations before ready

### DIFF
--- a/packages/bygger/src/context/notifications/FeedbackContext.tsx
+++ b/packages/bygger/src/context/notifications/FeedbackContext.tsx
@@ -14,7 +14,11 @@ const FeedbackProvider = ({ children }: { children: React.ReactElement }) => {
   const [messages, messageQueue] = useMessageQueue();
 
   useEffect(() => {
-    const callback = (error) => messageQueue.push({ message: error, type: "error" });
+    const callback = (error) => {
+      if (error?.reason?.message) {
+        messageQueue.push({ message: error.reason.message, type: "error" });
+      }
+    };
     window.addEventListener("unhandledrejection", callback);
     return () => window.removeEventListener("unhandledrejection", callback);
   }, [messageQueue]);

--- a/packages/bygger/src/context/notifications/FeedbackContext.tsx
+++ b/packages/bygger/src/context/notifications/FeedbackContext.tsx
@@ -14,7 +14,7 @@ const FeedbackProvider = ({ children }: { children: React.ReactElement }) => {
   const [messages, messageQueue] = useMessageQueue();
 
   useEffect(() => {
-    const callback = (error) => {
+    const callback = (error: PromiseRejectionEvent) => {
       if (error?.reason?.message) {
         messageQueue.push({ message: error.reason.message, type: "error" });
       }

--- a/packages/shared-domain/src/utils/localization.js
+++ b/packages/shared-domain/src/utils/localization.js
@@ -10,6 +10,9 @@ const getLanguageCodeAsIso639_1 = (locale) => {
 };
 
 const zipCountryNames = (keyNames, valueNames, mapToValue = (value) => value) => {
+  if (keyNames.length !== valueNames.length) {
+    return {};
+  }
   keyNames.sort((first, second) => first.value.localeCompare(second.value, "nb"));
   valueNames.sort((first, second) => first.value.localeCompare(second.value, "nb"));
   return keyNames.reduce(


### PR DESCRIPTION
Oppstår fordi brukernotifikasjonene ikke er satt opp til å håndtere PromiseRejectionEvent. Trigges av at “skjematekster” har sneket seg inn som språket på en global oversettelse.