### PR TITLE
Fix: unable to set "Papir og digital" on ettersending

### DIFF
--- a/packages/bygger/src/Forms/FormSettingsPage.jsx
+++ b/packages/bygger/src/Forms/FormSettingsPage.jsx
@@ -19,13 +19,13 @@ const useStyles = makeStyles({
   },
 });
 
-export function FormSettingsPage({ form, publishedForm, onSave, onChange, onPublish, onUnpublish, validateAndSave }) {
+export function FormSettingsPage({ form, publishedForm, onSave, onChange, onPublish, onUnpublish }) {
   const title = form.title;
   const [openPublishSettingModal, setOpenPublishSettingModal] = useModal(false);
   const styles = useStyles();
   const [errors, setErrors] = useState({});
 
-  validateAndSave = async (form) => {
+  const validateAndSave = async (form) => {
     const updatedErrors = validateFormMetadata(form, 'edit');
     if (isFormMetadataValid(updatedErrors)) {
       setErrors({});

--- a/packages/bygger/src/components/FormMetaDataEditor/SubmissionTypeSelect.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/SubmissionTypeSelect.tsx
@@ -4,15 +4,14 @@ interface Props {
   name: string;
   label: any;
   value: string | undefined;
-  allowEmpty?: boolean;
   error?: any;
   onChange: (event: any) => void;
 }
 
-const SubmissionTypeSelect = ({ name, label, value, allowEmpty, onChange, error }: Props) => {
+const SubmissionTypeSelect = ({ name, label, value, onChange, error }: Props) => {
   return (
     <Select className="mb" label={label} name={name} id={name} value={value} onChange={onChange} error={error}>
-      {allowEmpty && <option value="">Velg innsendingstype</option>}
+      <option value="">Velg innsendingstype</option>
       <option value="PAPIR_OG_DIGITAL">Papir og digital</option>
       <option value="KUN_PAPIR">Kun papir</option>
       <option value="KUN_DIGITAL">Kun digital</option>

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
@@ -12,7 +12,7 @@ export interface SubmissionFieldsProps {
 }
 
 const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProps) => {
-  const innsending = form.properties.innsending || 'PAPIR_OG_DIGITAL';
+  const innsending = form.properties.innsending;
   const ettersending = form.properties.ettersending;
   const ettersendelsesfrist = form.properties.ettersendelsesfrist;
 
@@ -22,6 +22,7 @@ const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProp
         name="form-innsending"
         label={<LabelWithDiff label="Innsending" diff={!!diff.innsending} />}
         value={innsending}
+        error={errors?.innsending}
         onChange={(event) =>
           onChange({
             ...form,
@@ -34,7 +35,6 @@ const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProp
         name="form-ettersending"
         label={<LabelWithDiff label="Ettersending" diff={!!diff.ettersending} />}
         value={ettersending}
-        allowEmpty={true}
         error={errors?.ettersending}
         onChange={(event) =>
           onChange({

--- a/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
+++ b/packages/bygger/src/components/FormMetaDataEditor/fields/SubmissionFields.tsx
@@ -13,7 +13,7 @@ export interface SubmissionFieldsProps {
 
 const SubmissionFields = ({ onChange, diff, form, errors }: SubmissionFieldsProps) => {
   const innsending = form.properties.innsending || 'PAPIR_OG_DIGITAL';
-  const ettersending = form.properties.ettersending || 'PAPIR_OG_DIGITAL';
+  const ettersending = form.properties.ettersending;
   const ettersendelsesfrist = form.properties.ettersendelsesfrist;
 
   return (

--- a/packages/bygger/src/components/FormMetaDataEditor/utils.ts
+++ b/packages/bygger/src/components/FormMetaDataEditor/utils.ts
@@ -17,6 +17,9 @@ export const validateFormMetadata = (form: NavFormType, usageContext: UsageConte
 
   // Some fields are only required in edit mode
   if (usageContext === 'edit') {
+    if (!form.properties.innsending) {
+      errors.innsending = 'Du må velge innsendingstype';
+    }
     if (!form.properties.ettersending) {
       errors.ettersending = 'Du må velge innsendingstype for ettersending';
     }


### PR DESCRIPTION
Some forms have form.properties.ettersending set as undefined. Since we validate ettersending onSave based on form.properties (not the input components) we should not use default values for required fields.