### PR TITLE
Fix mocks warning: Collection with id 'fyllut-base' is invalid

### DIFF
--- a/mocks/mocks/collections.json
+++ b/mocks/mocks/collections.json
@@ -13,7 +13,6 @@
       "post-soknad:success",
       "put-soknad:success",
       "get-soknad:success",
-      "get-soknad:not-found",
       "delete-soknad:success",
       "put-utfylt-soknad:success",
       "post-send-inn:success",

--- a/packages/fyllut/cypress/e2e/mellomlagring.cy.ts
+++ b/packages/fyllut/cypress/e2e/mellomlagring.cy.ts
@@ -86,7 +86,6 @@ describe('Mellomlagring', () => {
       cy.intercept('GET', '/fyllut/api/send-inn/soknad/8e3c3621-76d7-4ebd-90d4-34448ebcccc3').as(
         'getMellomlagringValid',
       );
-      cy.intercept('GET', '/fyllut/api/send-inn/soknad/not-found').as('getMellomlagringNotFound');
       cy.intercept('GET', `/fyllut/api/send-inn/soknad/f99dc639-add1-468f-b4bb-961cdfd1e599`).as(
         'getMellomlagringForInnsendingWithUpdateError',
       );
@@ -136,10 +135,14 @@ describe('Mellomlagring', () => {
     });
 
     it('redirects to start of application if an application with the "innsendingsId" from the url is not found', () => {
-      cy.visit('/fyllut/testmellomlagring/oppsummering?sub=digital&innsendingsId=not-found&lang=nb-NO');
+      cy.mocksUseRouteVariant('get-soknad:not-found');
+
+      cy.visit(
+        '/fyllut/testmellomlagring/oppsummering?sub=digital&innsendingsId=8e3c3621-76d7-4ebd-90d4-34448ebcccc3&lang=nb-NO',
+      );
       cy.wait('@getTestMellomlagringForm');
-      cy.wait('@getMellomlagringNotFound');
-      cy.url().should('not.include', 'not-found');
+      cy.wait('@getMellomlagringValid');
+      cy.url().should('not.include', '8e3c3621-76d7-4ebd-90d4-34448ebcccc3');
       cy.url().should('not.include', 'sub=digital');
       cy.url().should('not.include', 'oppsummering');
       cy.url().should('equal', `${Cypress.env('BASE_URL')}/fyllut/testmellomlagring`);


### PR DESCRIPTION
Route with id 'get-soknad' is used more than once in the same collection. Also correct test data where innsendingId was 'not-found', which is not a valid id. Fyllut backend will reject it with 404, but since a new mocks route (get-soknad:not-found) was added it seems like the test expected that this route should be invoked.