### PR TITLE
Fix report urls

### DIFF
--- a/packages/bygger-backend/src/services/ReportService.test.ts
+++ b/packages/bygger-backend/src/services/ReportService.test.ts
@@ -428,7 +428,7 @@ describe('ReportService', () => {
         const formFields3 = report.forms[2];
 
         const fyllutBaseUrl = 'https://fyllut-preprod.intern.dev.nav.no/fyllut';
-        const ettersendingBaseUrl = 'https://fyllut-ettersending.intern.dev.nav.no/fyllut-ettersending/detaljer';
+        const ettersendingBaseUrl = 'https://fyllut-ettersending.intern.dev.nav.no/fyllut-ettersending';
 
         // innsending: PAPIR_OG_DIGITAL, ettersending: PAPIR_OG_DIGITAL, 1 attachment
         expect(formFields1[report.getHeaderIndex(HEADER_INNSENDING)]).toBe(`${fyllutBaseUrl}/test1`);
@@ -439,15 +439,15 @@ describe('ReportService', () => {
         );
 
         // innsending: INGEN, ettersending: KUN_PAPIR, 0 attachments
-        expect(formFields2[report.getHeaderIndex(HEADER_INNSENDING)]).toBe(``);
+        expect(formFields2[report.getHeaderIndex(HEADER_INNSENDING)]).toBe(`${fyllutBaseUrl}/test2`);
         expect(formFields2[report.getHeaderIndex(HEADER_INNSENDING_PAPER)]).toBe(`${fyllutBaseUrl}/test2`);
         expect(formFields2[report.getHeaderIndex(HEADER_ETTERSENDING)]).toBe(``); // no attachments
         expect(formFields2[report.getHeaderIndex(HEADER_ETTERSENDING_PAPER)]).toBe(``);
 
         // innsending: KUN_PAPIR, ettersending: KUN_PAPIR, 1 attachments
-        expect(formFields3[report.getHeaderIndex(HEADER_INNSENDING)]).toBe(``);
+        expect(formFields3[report.getHeaderIndex(HEADER_INNSENDING)]).toBe(`${fyllutBaseUrl}/test3`);
         expect(formFields3[report.getHeaderIndex(HEADER_INNSENDING_PAPER)]).toBe(`${fyllutBaseUrl}/test3?sub=paper`);
-        expect(formFields3[report.getHeaderIndex(HEADER_ETTERSENDING)]).toBe(``);
+        expect(formFields3[report.getHeaderIndex(HEADER_ETTERSENDING)]).toBe(`${ettersendingBaseUrl}/test3`);
         expect(formFields3[report.getHeaderIndex(HEADER_ETTERSENDING_PAPER)]).toBe(
           `${ettersendingBaseUrl}/test3?sub=paper`,
         );

--- a/packages/bygger-backend/src/services/ReportService.ts
+++ b/packages/bygger-backend/src/services/ReportService.ts
@@ -149,7 +149,6 @@ class ReportService {
           ? `https://www.nav.no/fyllut-ettersending/${form.path}`
           : `https://fyllut-ettersending.intern.dev.nav.no/fyllut-ettersending/${form.path}`;
 
-      const innsendingUrl = baseInnsendingUrl;
       const paperInnsendingUrl = navFormUtils.isNone('innsending', form)
         ? `${baseInnsendingUrl}`
         : navFormUtils.isPaper('innsending', form)
@@ -183,7 +182,7 @@ class ReportService {
         hasAttachment ? 'ja' : 'nei',
         numberOfAttachments,
         attachmentNames,
-        innsendingUrl || '',
+        baseInnsendingUrl || '',
         paperInnsendingUrl || '',
         ettersendingUrl || '',
         paperEttersendingUrl || '',

--- a/packages/bygger-backend/src/services/ReportService.ts
+++ b/packages/bygger-backend/src/services/ReportService.ts
@@ -146,18 +146,17 @@ class ReportService {
           : `https://fyllut-preprod.intern.dev.nav.no/fyllut/${form.path}`;
       const baseEttersendingUrl =
         config.naisClusterName === 'prod-gcp'
-          ? `https://www.nav.no/fyllut-ettersending/detaljer/${form.path}`
-          : `https://fyllut-ettersending.intern.dev.nav.no/fyllut-ettersending/detaljer/${form.path}`;
+          ? `https://www.nav.no/fyllut-ettersending/${form.path}`
+          : `https://fyllut-ettersending.intern.dev.nav.no/fyllut-ettersending/${form.path}`;
 
-      const innsendingUrl = navFormUtils.isDigital('innsending', form) ? `${baseInnsendingUrl}` : undefined;
+      const innsendingUrl = baseInnsendingUrl;
       const paperInnsendingUrl = navFormUtils.isNone('innsending', form)
         ? `${baseInnsendingUrl}`
         : navFormUtils.isPaper('innsending', form)
         ? `${baseInnsendingUrl}?sub=paper`
         : undefined;
 
-      const ettersendingUrl =
-        navFormUtils.isDigital('ettersending', form) && hasAttachment ? `${baseEttersendingUrl}` : undefined;
+      const ettersendingUrl = hasAttachment ? baseEttersendingUrl : undefined;
       const paperEttersendingUrl =
         navFormUtils.isPaper('ettersending', form) && hasAttachment ? `${baseEttersendingUrl}?sub=paper` : undefined;
 


### PR DESCRIPTION
- `innsendingsurl` should always be present
- `ettersendingsurl` should be present if the form has attachments
- Updated to the new `ettersendingsurl` wihout `detaljer` 