### PR TITLE
Add min-width to builder components

### DIFF
--- a/packages/shared-components/src/styles/form/builderComponents.ts
+++ b/packages/shared-components/src/styles/form/builderComponents.ts
@@ -1,0 +1,8 @@
+const builderComponents = {
+  // To be able to see all the buttons in the builder
+  '& .builder-components': {
+    minWidth: '100%',
+  },
+};
+
+export default builderComponents;

--- a/packages/shared-components/src/styles/form/index.ts
+++ b/packages/shared-components/src/styles/form/index.ts
@@ -1,4 +1,5 @@
 import alert from './alert';
+import builderComponents from './builderComponents';
 import button from './button';
 import choices from './choices';
 import datagrid from './datagrid';
@@ -25,6 +26,7 @@ import typography from './typography';
 const form = {
   '.formio-form': {
     ...alert,
+    ...builderComponents,
     ...button,
     ...choices,
     ...datepicker,


### PR DESCRIPTION
To be able to see the buttons properly.

Before:
![Skjermbilde 2024-01-24 kl  12 42 58](https://github.com/navikt/skjemabygging-formio/assets/7783861/e2960380-402a-4a65-94cf-10d1284e23a2)

After:
![Skjermbilde 2024-01-24 kl  12 42 36](https://github.com/navikt/skjemabygging-formio/assets/7783861/a03919ba-61ff-42f5-a8a6-140db85db7be)
