### PR TITLE
Temporary workaround for soknad med visningstype dokumentinnsending

### DIFF
--- a/packages/fyllut-backend/src/routers/api/send-inn-soknad.ts
+++ b/packages/fyllut-backend/src/routers/api/send-inn-soknad.ts
@@ -73,7 +73,9 @@ const sendInnSoknad = {
         ...json,
         hoveddokumentVariant: {
           ...json.hoveddokumentVariant,
-          document: byteArrayToObject(base64Decode(json.hoveddokumentVariant.document)),
+          ...(json.hoveddokumentVariant.document && {
+            document: byteArrayToObject(base64Decode(json.hoveddokumentVariant.document)),
+          }),
         },
       };
       res.json(response);

--- a/packages/fyllut/src/components/FormPageWrapper.test.jsx
+++ b/packages/fyllut/src/components/FormPageWrapper.test.jsx
@@ -2,6 +2,7 @@ import { AppConfigProvider } from '@navikt/skjemadigitalisering-shared-component
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
+import httpFyllut from '../util/httpFyllut';
 import { FormPageWrapper } from './FormPageWrapper';
 
 const RESPONSE_HEADERS = {
@@ -30,9 +31,11 @@ describe('FormPageWrapper', () => {
 
     render(
       <MemoryRouter initialEntries={['/fyllut/unknownForm']}>
-        <Routes>
-          <Route path="/fyllut/:formPath/*" element={<FormPageWrapper />} />
-        </Routes>
+        <AppConfigProvider featureToggles={{}} config={{}} http={httpFyllut}>
+          <Routes>
+            <Route path="/fyllut/:formPath/*" element={<FormPageWrapper />} />
+          </Routes>
+        </AppConfigProvider>
       </MemoryRouter>,
     );
 
@@ -64,7 +67,7 @@ describe('FormPageWrapper', () => {
 
     render(
       <MemoryRouter initialEntries={['/fyllut/knownForm']}>
-        <AppConfigProvider featureToggles={{}} config={{}}>
+        <AppConfigProvider featureToggles={{}} config={{}} http={httpFyllut}>
           <Routes>
             <Route path="/fyllut/:formPath/*" element={<FormPageWrapper />} />
           </Routes>
@@ -98,7 +101,7 @@ describe('FormPageWrapper', () => {
     it('Show error message when submission method is invalid', async () => {
       render(
         <MemoryRouter initialEntries={['/fyllut/nav123456']}>
-          <AppConfigProvider featureToggles={{}} config={{}} submissionMethod="digital">
+          <AppConfigProvider featureToggles={{}} config={{}} submissionMethod="digital" http={httpFyllut}>
             <Routes>
               <Route path="/fyllut/:formPath/*" element={<FormPageWrapper />} />
             </Routes>
@@ -114,7 +117,7 @@ describe('FormPageWrapper', () => {
     it('Show form title when submission method is valid', async () => {
       render(
         <MemoryRouter initialEntries={['/fyllut/nav123456']}>
-          <AppConfigProvider featureToggles={{}} config={{}} submissionMethod="paper">
+          <AppConfigProvider featureToggles={{}} config={{}} submissionMethod="paper" http={httpFyllut}>
             <Routes>
               <Route path="/fyllut/:formPath/*" element={<FormPageWrapper />} />
             </Routes>

--- a/packages/fyllut/src/components/FormPageWrapper.tsx
+++ b/packages/fyllut/src/components/FormPageWrapper.tsx
@@ -23,24 +23,26 @@ export const FormPageWrapper = () => {
       })
       .catch((err) => {
         // Temporary workaround. Remove in eight weeks :)
-        const innsendingsId = searchParams.get('innsendingsId');
-        if (innsendingsId) {
-          http
-            ?.get<{ visningsType }>(`/fyllut/api/send-inn/soknad/${innsendingsId}`)
-            .then((soknad) => {
-              if (soknad?.visningsType === 'dokumentinnsending') {
-                const isDevGcp = config?.NAIS_CLUSTER_NAME === 'dev-gcp';
-                const baseUrl = isDevGcp ? 'https://www.intern.dev.nav.no' : 'https://www.nav.no';
-                logger?.info('Redirigerer søknad med visningstype dokumentinnsending', { baseUrl, innsendingsId });
-                window.location.href = `${baseUrl}/sendinn/${innsendingsId}`;
-              }
-            })
-            .catch((err) => {
-              logger?.info('Redirigering av søknad med visningstype dokumentinnsending feilet', {
-                innsendingsId,
-                errorMessage: err?.message,
+        if (err instanceof http!.HttpError && err.status === 404) {
+          const innsendingsId = searchParams.get('innsendingsId');
+          if (innsendingsId) {
+            http!
+              .get<{ visningsType }>(`/fyllut/api/send-inn/soknad/${innsendingsId}`)
+              .then((soknad) => {
+                if (soknad?.visningsType === 'dokumentinnsending') {
+                  const isDevGcp = config?.NAIS_CLUSTER_NAME === 'dev-gcp';
+                  const baseUrl = isDevGcp ? 'https://www.intern.dev.nav.no' : 'https://www.nav.no';
+                  logger?.info('Redirigerer søknad med visningstype dokumentinnsending', { baseUrl, innsendingsId });
+                  window.location.href = `${baseUrl}/sendinn/${innsendingsId}`;
+                }
+              })
+              .catch((err) => {
+                logger?.info('Redirigering av søknad med visningstype dokumentinnsending feilet', {
+                  innsendingsId,
+                  errorMessage: err?.message,
+                });
               });
-            });
+          }
         }
         setStatus(err instanceof httpFyllut.UnauthenticatedError ? 'UNAUTHENTICATED' : 'FORM NOT FOUND');
       });

--- a/packages/fyllut/src/components/FormPageWrapper.tsx
+++ b/packages/fyllut/src/components/FormPageWrapper.tsx
@@ -26,9 +26,9 @@ export const FormPageWrapper = () => {
         const innsendingsId = searchParams.get('innsendingsId');
         if (innsendingsId) {
           http
-            ?.get<{ visningstype }>(`/fyllut/api/send-inn/soknad/${innsendingsId}`)
+            ?.get<{ visningsType }>(`/fyllut/api/send-inn/soknad/${innsendingsId}`)
             .then((soknad) => {
-              if (soknad?.visningstype === 'dokumentinnsending') {
+              if (soknad?.visningsType === 'dokumentinnsending') {
                 const isDevGcp = config?.NAIS_CLUSTER_NAME === 'dev-gcp';
                 const baseUrl = isDevGcp ? 'https://www.intern.dev.nav.no' : 'https://www.nav.no';
                 logger?.info('Redirigerer søknad med visningstype dokumentinnsending', { baseUrl, innsendingsId });


### PR DESCRIPTION
If form definition is not found, check to see if soknad.visningsgtype is 'dokumentinnsending', and redirect to sendinn if it is.