### PR TITLE
Bugfix: Radiopanel legend should never be hidden

### DIFF
--- a/packages/shared-components/src/formio/components/core/radio/Radio.tsx
+++ b/packages/shared-components/src/formio/components/core/radio/Radio.tsx
@@ -57,7 +57,6 @@ class Radio extends BaseComponent {
         value={this.getValue()}
         onChange={(value) => this.changeHandler(value, { modified: true })}
         ref={(ref) => this.setReactInstance(ref)}
-        hideLegend={this.getHideLabel()}
         description={this.getDescription()}
         className={this.getClassName()}
         readOnly={this.getReadOnly()}


### PR DESCRIPTION
despite the fact that dataGridLabel=false in published forms.