### PR TITLE
Problem with required label on panel and double labels in builder

### DIFF
--- a/packages/shared-components/src/formio/template/templates/navdesign/field/form.ejs
+++ b/packages/shared-components/src/formio/template/templates/navdesign/field/form.ejs
@@ -5,7 +5,7 @@
       <div class="description" id="d-{{ctx.instance.id}}-{{ctx.component.key}}">{{ctx.t(ctx.component.description, { _userInput: true })}}</div>
     {% } %}
 
-    {% if (ctx.component.label && (ctx.builder || (!ctx.component.hideLabel && ctx.component.type !== "radio" && ctx.component.type !== "container" && ctx.component.type !== "alertstripe" && ctx.component.type !== "selectboxes" && ctx.component.type !== "navCheckbox" && ctx.component.type !== "datagrid" && ctx.component.type !== "navSkjemagruppe" && !ctx.component.isNavCheckboxPanel))) { %}
+    {% if (ctx.component.label && ((ctx.builder || !ctx.component.hideLabel) && ctx.component.type !== "radio" && ctx.component.type !== "container" && ctx.component.type !== "alertstripe" && ctx.component.type !== "selectboxes" && ctx.component.type !== "navCheckbox" && ctx.component.type !== "datagrid" && ctx.component.type !== "navSkjemagruppe" && !ctx.component.isNavCheckboxPanel)) { %}
       {{ ctx.labelMarkup }}
     {% } %}
 

--- a/packages/shared-components/src/formio/template/templates/navdesign/field/form.ejs
+++ b/packages/shared-components/src/formio/template/templates/navdesign/field/form.ejs
@@ -5,7 +5,7 @@
       <div class="description" id="d-{{ctx.instance.id}}-{{ctx.component.key}}">{{ctx.t(ctx.component.description, { _userInput: true })}}</div>
     {% } %}
 
-    {% if (ctx.builder || (ctx.component.label && !ctx.component.hideLabel && ctx.component.type !== "radio" && ctx.component.type !== "container" && ctx.component.type !== "alertstripe" && ctx.component.type !== "selectboxes" && ctx.component.type !== "navCheckbox" && ctx.component.type !== "datagrid" && ctx.component.type !== "navSkjemagruppe" && !ctx.component.isNavCheckboxPanel)) { %}
+    {% if (ctx.component.label && (ctx.builder || (!ctx.component.hideLabel && ctx.component.type !== "radio" && ctx.component.type !== "container" && ctx.component.type !== "alertstripe" && ctx.component.type !== "selectboxes" && ctx.component.type !== "navCheckbox" && ctx.component.type !== "datagrid" && ctx.component.type !== "navSkjemagruppe" && !ctx.component.isNavCheckboxPanel))) { %}
       {{ ctx.labelMarkup }}
     {% } %}
 


### PR DESCRIPTION
Error in logic when trying to get rid of the old formio labelIsHidden(). 

- Do not show if label is not set
- Check on bulder OR hideLabel (need to respect components with their own labels.

`  labelIsHidden() {
    return !this.component.label ||
      ((!this.isInDataGrid && this.component.hideLabel) ||
      (this.isInDataGrid && !this.component.dataGridLabel) ||
      this.options.inputsOnly) && !this.builderMode;
  }
`