### PR TITLE
Fix validation errors for activities component

### DIFF
--- a/mocks/mocks/data/innsending-api/activities/mellomlagring-activities-prefilled-maalgruppe.json
+++ b/mocks/mocks/data/innsending-api/activities/mellomlagring-activities-prefilled-maalgruppe.json
@@ -37,7 +37,6 @@
             },
             "aktivitet": {
               "aktivitetId": "ingenAktivitet",
-              "maalgruppe": { "maalgruppetype": "ANNET" },
               "text": "Jeg får ikke opp noen aktiviteter her som stemmer med det jeg vil søke om"
             }
           }

--- a/mocks/mocks/data/innsending-api/activities/mellomlagring-activities-prefilled-maalgruppe.json
+++ b/mocks/mocks/data/innsending-api/activities/mellomlagring-activities-prefilled-maalgruppe.json
@@ -37,11 +37,7 @@
             },
             "aktivitet": {
               "aktivitetId": "ingenAktivitet",
-              "maalgruppe": "",
-              "periode": {
-                "fom": "",
-                "tom": ""
-              },
+              "maalgruppe": { "maalgruppetype": "ANNET" },
               "text": "Jeg får ikke opp noen aktiviteter her som stemmer med det jeg vil søke om"
             }
           }

--- a/packages/fyllut/cypress/e2e/components/activities.cy.ts
+++ b/packages/fyllut/cypress/e2e/components/activities.cy.ts
@@ -16,8 +16,7 @@ import activitiesJson from '../../../../../mocks/mocks/data/innsending-api/activ
 
 const defaultActivity: SubmissionActivity = {
   aktivitetId: 'ingenAktivitet',
-  maalgruppe: { maalgruppetype: '', gyldighetsperiode: { fom: '', tom: '' }, maalgruppenavn: '' },
-  periode: { fom: '', tom: '' },
+  maalgruppe: { maalgruppetype: 'ANNET' },
   text: TEXTS.statiske.activities.defaultActivity,
 };
 
@@ -41,19 +40,19 @@ const verifySubmissionValues = (maalgruppe: SubmissionMaalgruppe, aktivitet: Par
     } = req.body;
 
     expect(aktivitetMaalgruppeSubmission.aktivitet.aktivitetId).to.equal(aktivitet.aktivitetId);
-    expect(aktivitetMaalgruppeSubmission.aktivitet.periode.fom).to.equal(aktivitet.periode.fom);
-    expect(aktivitetMaalgruppeSubmission.aktivitet.periode.tom).to.equal(aktivitet.periode.tom);
+    expect(aktivitetMaalgruppeSubmission.aktivitet.periode?.fom).to.equal(aktivitet.periode?.fom);
+    expect(aktivitetMaalgruppeSubmission.aktivitet.periode?.tom).to.equal(aktivitet.periode?.tom);
 
     // Activity målgruppe (if selected)
     if (aktivitetMaalgruppeSubmission.aktivitet.maalgruppe) {
       expect(aktivitetMaalgruppeSubmission.aktivitet.maalgruppe.maalgruppetype).to.equal(
         aktivitet.maalgruppe.maalgruppetype,
       );
-      expect(aktivitetMaalgruppeSubmission.aktivitet.maalgruppe.gyldighetsperiode.fom).to.equal(
-        aktivitet.maalgruppe.gyldighetsperiode.fom,
+      expect(aktivitetMaalgruppeSubmission.aktivitet.maalgruppe.gyldighetsperiode?.fom).to.equal(
+        aktivitet.maalgruppe.gyldighetsperiode?.fom,
       );
-      expect(aktivitetMaalgruppeSubmission.aktivitet.maalgruppe.gyldighetsperiode.tom).to.equal(
-        aktivitet.maalgruppe.gyldighetsperiode.tom,
+      expect(aktivitetMaalgruppeSubmission.aktivitet.maalgruppe.gyldighetsperiode?.tom).to.equal(
+        aktivitet.maalgruppe.gyldighetsperiode?.tom,
       );
     }
 
@@ -374,6 +373,19 @@ describe('Activities', () => {
       cy.findByRole('checkbox', { name: defaultActivity.text }).should('exist');
 
       cy.get('.navds-alert--info').contains(TEXTS.statiske.activities.errorContinue);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('should show validation errors', () => {
+      cy.visit(`/fyllut/testingactivities?sub=digital`);
+      cy.defaultWaits();
+      cy.clickStart();
+      cy.wait('@getActivities');
+
+      cy.clickSaveAndContinue();
+
+      cy.findByRole('link', { name: `Du må fylle ut: ${TEXTS.statiske.activities.label}` }).should('exist');
     });
   });
 });

--- a/packages/fyllut/cypress/e2e/components/activities.cy.ts
+++ b/packages/fyllut/cypress/e2e/components/activities.cy.ts
@@ -16,7 +16,6 @@ import activitiesJson from '../../../../../mocks/mocks/data/innsending-api/activ
 
 const defaultActivity: SubmissionActivity = {
   aktivitetId: 'ingenAktivitet',
-  maalgruppe: { maalgruppetype: 'ANNET' },
   text: TEXTS.statiske.activities.defaultActivity,
 };
 

--- a/packages/shared-components/src/formio/components/base/BaseComponent.tsx
+++ b/packages/shared-components/src/formio/components/base/BaseComponent.tsx
@@ -41,7 +41,7 @@ class BaseComponent extends FormioReactComponent {
    */
   getLabel(options?: { showOptional?: boolean; showDiffTag?: boolean; labelTextOnly?: boolean }) {
     const defaultOptions = { showOptional: true, showDiffTag: true, labelTextOnly: false };
-    const { showOptional, showDiffTag, labelTextOnly } = { ...defaultOptions, ...options };
+    const { showOptional, showDiffTag, labelTextOnly } = { ...defaultOptions, ...(options ?? {}) };
 
     if (labelTextOnly) return this.t(this.component?.label ?? '');
 

--- a/packages/shared-components/src/formio/components/base/BaseComponent.tsx
+++ b/packages/shared-components/src/formio/components/base/BaseComponent.tsx
@@ -49,6 +49,10 @@ class BaseComponent extends FormioReactComponent {
     );
   }
 
+  getLabelText() {
+    return this.t(this.component?.label ?? '');
+  }
+
   /**
    * Set which component is currently focused, and optionally which element inside this component.
    * This is stored on 'this.root' which usually points to the webform/wizard.

--- a/packages/shared-components/src/formio/components/base/BaseComponent.tsx
+++ b/packages/shared-components/src/formio/components/base/BaseComponent.tsx
@@ -39,18 +39,21 @@ class BaseComponent extends FormioReactComponent {
   /**
    * Get label for custom component renderReact()
    */
-  getLabel() {
+  getLabel(options?: { showOptional?: boolean; showDiffTag?: boolean; labelTextOnly?: boolean }) {
+    const defaultOptions = { showOptional: true, showDiffTag: true, labelTextOnly: false };
+    const { showOptional, showDiffTag, labelTextOnly } = { ...defaultOptions, ...options };
+
+    if (labelTextOnly) return this.t(this.component?.label ?? '');
+
     return (
       <>
         {this.t(this.component?.label ?? '')}
-        {this.component?.validate?.required && !this.component?.readOnly ? '' : ` (${this.t('valgfritt')})`}
-        {this.getDiffTag()}
+        {this.component?.validate?.required && !this.component?.readOnly
+          ? ''
+          : showOptional && ` (${this.t('valgfritt')})`}
+        {showDiffTag && this.getDiffTag()}
       </>
     );
-  }
-
-  getLabelText() {
-    return this.t(this.component?.label ?? '');
   }
 
   /**

--- a/packages/shared-components/src/formio/components/core/activities/Activities.builder.ts
+++ b/packages/shared-components/src/formio/components/core/activities/Activities.builder.ts
@@ -8,7 +8,7 @@ const activitiesBuilder = () => {
       ...schema,
       validateOn: 'blur',
       validate: {
-        required: true,
+        required: false, // Handled by custom validation
       },
     },
   };

--- a/packages/shared-components/src/formio/components/core/activities/Activities.tsx
+++ b/packages/shared-components/src/formio/components/core/activities/Activities.tsx
@@ -9,10 +9,10 @@ class Activities extends BaseComponent {
   isLoading = false;
   loadFinished = false;
   activities?: SendInnAktivitet[] = undefined;
+
   defaultActivity: SubmissionActivity = {
     aktivitetId: 'ingenAktivitet',
-    maalgruppe: { maalgruppetype: '', maalgruppenavn: '', gyldighetsperiode: { fom: '', tom: '' } },
-    periode: { fom: '', tom: '' },
+    maalgruppe: { maalgruppetype: 'ANNET' },
     text: this.t(TEXTS.statiske.activities.defaultActivity),
   };
 
@@ -21,6 +21,7 @@ class Activities extends BaseComponent {
       label: 'Velg hvilken aktivitet du vil søke om stønad for',
       type: 'activities',
       key: 'aktivitet',
+      input: true,
     });
   }
 
@@ -30,6 +31,38 @@ class Activities extends BaseComponent {
 
   static get builderInfo() {
     return activitiesBuilder();
+  }
+
+  override get errors() {
+    return this.componentErrors;
+  }
+
+  override getError(): string | undefined {
+    const error = this.componentErrors.find((error) => error.path === this.getId());
+    if (error) return error.message;
+  }
+
+  override checkValidity(): boolean {
+    this.removeAllErrors();
+
+    const submissionMethod = this.getAppConfig()?.submissionMethod;
+
+    if (submissionMethod === 'digital') {
+      const componentData = this.getValue() as SubmissionActivity;
+
+      if (!componentData) {
+        const requiredError = this.t('required', { field: this.getLabelText() });
+        super.addError(this.getId(), requiredError);
+      }
+    }
+
+    this.rerender();
+
+    if (this.componentErrors.length > 0) {
+      return false;
+    }
+
+    return true;
   }
 
   // The radio/checkbox values are simple strings, but the whole activity object is stored in the submission
@@ -44,9 +77,10 @@ class Activities extends BaseComponent {
   renderReact(element) {
     element.render(
       <>
+        {this.getDiffTag()}
         <NavActivities
           id={this.getId()}
-          label={this.getLabel()}
+          label={this.getLabelText()}
           value={this.getValue()}
           onChange={(value, options) => this.changeHandler(value, options)}
           description={this.getDescription()}

--- a/packages/shared-components/src/formio/components/core/activities/Activities.tsx
+++ b/packages/shared-components/src/formio/components/core/activities/Activities.tsx
@@ -12,7 +12,6 @@ class Activities extends BaseComponent {
 
   defaultActivity: SubmissionActivity = {
     aktivitetId: 'ingenAktivitet',
-    maalgruppe: { maalgruppetype: 'ANNET' },
     text: this.t(TEXTS.statiske.activities.defaultActivity),
   };
 

--- a/packages/shared-components/src/formio/components/core/activities/Activities.tsx
+++ b/packages/shared-components/src/formio/components/core/activities/Activities.tsx
@@ -20,7 +20,6 @@ class Activities extends BaseComponent {
       label: 'Velg hvilken aktivitet du vil søke om stønad for',
       type: 'activities',
       key: 'aktivitet',
-      input: true,
     });
   }
 
@@ -50,7 +49,7 @@ class Activities extends BaseComponent {
       const componentData = this.getValue() as SubmissionActivity;
 
       if (!componentData) {
-        const requiredError = this.t('required', { field: this.getLabelText() });
+        const requiredError = this.t('required', { field: this.getLabel({ labelTextOnly: true }) });
         super.addError(this.getId(), requiredError);
       }
     }
@@ -79,7 +78,7 @@ class Activities extends BaseComponent {
         {this.getDiffTag()}
         <NavActivities
           id={this.getId()}
-          label={this.getLabelText()}
+          label={this.getLabel({ showOptional: false })}
           value={this.getValue()}
           onChange={(value, options) => this.changeHandler(value, options)}
           description={this.getDescription()}

--- a/packages/shared-components/src/formio/components/core/maalgruppe/Maalgruppe.test.ts
+++ b/packages/shared-components/src/formio/components/core/maalgruppe/Maalgruppe.test.ts
@@ -36,7 +36,6 @@ describe('calculateMaalgruppeValue function', () => {
       data: {
         aktivitet: {
           aktivitetId: 'ingenAktivitet',
-          maalgruppe: { maalgruppetype: 'ANNET' },
           text: '',
         },
       },

--- a/packages/shared-components/src/formio/components/core/maalgruppe/Maalgruppe.test.ts
+++ b/packages/shared-components/src/formio/components/core/maalgruppe/Maalgruppe.test.ts
@@ -36,8 +36,7 @@ describe('calculateMaalgruppeValue function', () => {
       data: {
         aktivitet: {
           aktivitetId: 'ingenAktivitet',
-          maalgruppe: '',
-          periode: { fom: '', tom: '' },
+          maalgruppe: { maalgruppetype: 'ANNET' },
           text: '',
         },
       },

--- a/packages/shared-domain/src/submission/activity.ts
+++ b/packages/shared-domain/src/submission/activity.ts
@@ -3,7 +3,7 @@ import { SendInnMaalgruppe } from '../sendinn/activity';
 export interface SubmissionActivity {
   aktivitetId: string;
   maalgruppe?: SendInnMaalgruppe;
-  periode: { fom: string; tom: string };
+  periode?: { fom: string; tom: string };
   text: string;
   vedtaksId?: string;
 }


### PR DESCRIPTION
With `required: true` in the schema definition, the field was validated on paper submissions even though it is hidden for paper submissions. 