### PR TITLE
Add check for http_response_body in logging

### DIFF
--- a/packages/fyllut-backend/src/security/azureAccessTokenHandler.ts
+++ b/packages/fyllut-backend/src/security/azureAccessTokenHandler.ts
@@ -24,7 +24,12 @@ const azureAccessTokenHandler = (scope: string) => async (req: Request, res: Res
     req.headers.AzureAccessToken = json.access_token;
     next();
   } catch (error: any) {
-    logger.error(`Access token failed with: ${JSON.stringify(error.http_response_body)}`);
+    if (error.http_response_body) {
+      logger.error(`Access token failed with: ${JSON.stringify(error.http_response_body)}`);
+    } else {
+      logger.error(`Access token failed with: ${JSON.stringify(error)}`);
+    }
+
     next(error);
   }
 };


### PR DESCRIPTION
If `fetch` function fails, the `toJsonOrThrowError` won't run and the error in the exception won't have `http_response_body`. All the logs show `undefined` for `error.http_response_body` so this fixes that so we can see what's causing the error