### PR TITLE
Don't include label of accordion

### DIFF
--- a/packages/bygger/src/translations/utils.ts
+++ b/packages/bygger/src/translations/utils.ts
@@ -107,6 +107,7 @@ const getLabel = (label: string, type: string, hideLabel: boolean) => {
     'navSkjemagruppe',
     'alertstripe',
     'image',
+    'accordion',
   ].includes(type);
   if (hideLabel || excludeLabelForType) return undefined;
   return label;


### PR DESCRIPTION
Jeg er litt usikker på om dette bør styres her eller av hideLabel på komponenten. Er det en mulighet for at vi i framtiden vil åpne for å vise label for trekkspill?