### PR TITLE
Remove datepicker autoformat on focus

### DIFF
--- a/packages/shared-components/src/components/datepicker/DatePicker.tsx
+++ b/packages/shared-components/src/components/datepicker/DatePicker.tsx
@@ -89,7 +89,9 @@ const DatePicker = ({
         label={label}
         description={description}
         className={className}
-        onFocus={() => {}}
+        onFocus={() => {
+          // Aksel do autoformat onFocus so we override focus to have control over formatting.
+        }}
         onBlur={(e) => {
           // Since we have problem listening on empty value on inputProps.value
           // we need to trigger onChange on blur when there is an empty value.

--- a/packages/shared-components/src/components/datepicker/DatePicker.tsx
+++ b/packages/shared-components/src/components/datepicker/DatePicker.tsx
@@ -89,6 +89,7 @@ const DatePicker = ({
         label={label}
         description={description}
         className={className}
+        onFocus={() => {}}
         onBlur={(e) => {
           // Since we have problem listening on empty value on inputProps.value
           // we need to trigger onChange on blur when there is an empty value.


### PR DESCRIPTION
Override Aksel default onFucus, since it format the date when clicking the input field.