### PR TITLE
update translation on change to get recent changes in native submit

### DIFF
--- a/packages/bygger/cypress/e2e/global-translations.spec.cy.ts
+++ b/packages/bygger/cypress/e2e/global-translations.spec.cy.ts
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 
-// TODO FORMS-API
-// eslint-disable-next-line mocha/no-skipped-tests
-describe.skip('Global translations', () => {
+describe('Global translations', () => {
   beforeEach(() => {
     cy.intercept('GET', '/api/config', { fixture: 'config.json' }).as('getConfig');
     cy.intercept('GET', '/api/translations', { fixture: 'formsApiGlobalTranslations.json' }).as(
@@ -186,7 +184,7 @@ describe.skip('Global translations', () => {
     it('updates new and existing translations', () => {
       cy.intercept('POST', '/api/translations', (req) => {
         expect(req.body).to.deep.equal({
-          key: 'validering.required',
+          key: 'required',
           nb: 'Du må fylle ut: {{field}}',
           nn: 'Du må fylle ut: {{field}}',
           en: 'You must fill in: {{field}}',

--- a/packages/bygger/cypress/fixtures/formsApiGlobalTranslations.json
+++ b/packages/bygger/cypress/fixtures/formsApiGlobalTranslations.json
@@ -79,7 +79,7 @@
   },
   {
     "id": 7,
-    "key": "validering.error",
+    "key": "error",
     "tag": "validering",
     "changedAt": "2024-12-12T13:03:19.063368+01:00",
     "changedBy": "Testesen, Test",

--- a/packages/bygger/src/context/translations/EditFormTranslationsContext.tsx
+++ b/packages/bygger/src/context/translations/EditFormTranslationsContext.tsx
@@ -6,7 +6,7 @@ import { editFormTranslationsReducer } from './editTranslationsReducer';
 import { getTranslationsForSaving } from './editTranslationsReducer/selectors';
 import { useFormTranslations } from './FormTranslationsContext';
 import { getConflictAlertMessage, getGeneralAlertMessage, TranslationError } from './utils/errorUtils';
-import { validateTranslations } from './utils/inputValidation';
+import { validateFormTranslations } from './utils/inputValidation';
 import { saveEachTranslation } from './utils/utils';
 
 interface Props {
@@ -64,7 +64,7 @@ const EditFormTranslationsProvider = ({ initialChanges, children }: Props) => {
 
   const saveChanges = async () => {
     const translations = getTranslationsForSaving<FormsApiFormTranslation>(state);
-    const validationErrors = validateTranslations(translations);
+    const validationErrors = validateFormTranslations(translations);
 
     if (validationErrors.length > 0) {
       dispatch({ type: 'VALIDATION_ERROR', payload: { errors: validationErrors } });

--- a/packages/bygger/src/context/translations/EditGlobalTranslationsContext.tsx
+++ b/packages/bygger/src/context/translations/EditGlobalTranslationsContext.tsx
@@ -8,7 +8,7 @@ import { createDefaultGlobalTranslation, Status } from './editTranslationsReduce
 import { getTranslationsForSaving, hasNewTranslationData } from './editTranslationsReducer/selectors';
 import { useGlobalTranslations } from './GlobalTranslationsContext';
 import { getConflictAlertMessage, getGeneralAlertMessage, TranslationError } from './utils/errorUtils';
-import { validate, validateTranslations } from './utils/inputValidation';
+import { validateGlobalTranslations, validateNewGlobalTranslation } from './utils/inputValidation';
 import { saveEachTranslation } from './utils/utils';
 
 interface Props {
@@ -77,11 +77,11 @@ const EditGlobalTranslationsProvider = ({ initialChanges, children }: Props) => 
 
   const saveChanges = async () => {
     const newTranslationHasData = hasNewTranslationData(state);
-    const newTranslationValidationError = newTranslationHasData && validate(state.new, true);
+    const newTranslationValidationError = newTranslationHasData && validateNewGlobalTranslation(state.new);
     const translations = getTranslationsForSaving<FormsApiGlobalTranslation>(state);
     const validationErrors: TranslationError[] = [
       ...(newTranslationValidationError ? [newTranslationValidationError] : []),
-      ...validateTranslations(translations),
+      ...validateGlobalTranslations(translations),
     ];
     if (validationErrors.length > 0) {
       dispatch({ type: 'VALIDATION_ERROR', payload: { errors: validationErrors } });

--- a/packages/bygger/src/context/translations/utils/inputValidation.ts
+++ b/packages/bygger/src/context/translations/utils/inputValidation.ts
@@ -1,34 +1,70 @@
-import { FormsApiTranslation } from '@navikt/skjemadigitalisering-shared-domain';
+import {
+  FormsApiFormTranslation,
+  FormsApiGlobalTranslation,
+  FormsApiTranslation,
+} from '@navikt/skjemadigitalisering-shared-domain';
 import { TranslationError } from './errorUtils';
 
+type Validator = (translation: FormsApiTranslation) => TranslationError | undefined;
+
+const MAX_INPUT_LENGTH_FORM_TRANSLATION = 5120;
+const MAX_INPUT_LENGTH_GLOBAL_TRANSLATION = 1024;
+
+const isInputTooLong = ({ key, nb = '', nn = '', en = '' }: FormsApiTranslation, maxLength: number) =>
+  key.length > maxLength || nb.length > maxLength || nn.length > maxLength || en.length > maxLength;
+const createInputTooLongValidator =
+  (maxLength: number, isNewTranslation = false): Validator =>
+  (translation: FormsApiTranslation): TranslationError | undefined => {
+    if (isInputTooLong(translation, maxLength)) {
+      return {
+        key: translation.key,
+        type: 'INPUT_TOO_LONG_VALIDATION',
+        message: `Teksten er for lang. Maksimal lengde er ${maxLength} tegn`,
+        isNewTranslation,
+      };
+    }
+  };
+
 const isMissingKey = (translation: FormsApiTranslation) => !translation.key;
+const createMissingKeyValidator =
+  (): Validator =>
+  (translation: FormsApiTranslation): TranslationError | undefined => {
+    if (isMissingKey(translation)) {
+      return {
+        key: translation.key,
+        type: 'MISSING_KEY_VALIDATION',
+        message: 'Legg til bokmålstekst for å opprette ny oversettelse',
+        isNewTranslation: true,
+      };
+    }
+  };
 
-const isInputTooLong = ({ key, nb = '', nn = '', en = '' }: FormsApiTranslation) =>
-  key.length > 1024 || nb.length > 1024 || nn.length > 1024 || en.length > 1024;
+const validateTranslation = (translation: FormsApiFormTranslation, validators: Validator[]) =>
+  validators.map((validator) => validator(translation)).find((error) => !!error);
 
-const validate = <T extends FormsApiTranslation>(
-  translation: T,
-  isNewTranslation: boolean = false,
-): TranslationError | undefined => {
-  if (isMissingKey(translation)) {
-    return {
-      key: translation.key,
-      type: 'MISSING_KEY_VALIDATION',
-      message: 'Legg til bokmålstekst for å opprette ny oversettelse',
-      isNewTranslation,
-    };
-  }
-  if (isInputTooLong(translation)) {
-    return {
-      key: translation.key,
-      type: 'INPUT_TOO_LONG_VALIDATION',
-      message: 'Teksten er for lang. Maksimal lengde er 1024 tegn',
-      isNewTranslation,
-    };
-  }
+const validateTranslations = (translations: FormsApiTranslation[], validators: Validator[]): TranslationError[] =>
+  translations
+    .map((translation) => {
+      return validators.map((validator) => validator(translation)).find((error) => !!error);
+    })
+    .filter((validationError) => !!validationError);
+
+const validateFormTranslations = (translations: FormsApiFormTranslation[]): TranslationError[] => {
+  const validators: Validator[] = [createInputTooLongValidator(MAX_INPUT_LENGTH_FORM_TRANSLATION)];
+  return validateTranslations(translations, validators);
 };
 
-const validateTranslations = (translations: FormsApiTranslation[]): TranslationError[] =>
-  translations.map((translation) => validate(translation)).filter((validationError) => !!validationError);
+const validateGlobalTranslations = (translations: FormsApiGlobalTranslation[]): TranslationError[] => {
+  const validators: Validator[] = [createInputTooLongValidator(MAX_INPUT_LENGTH_GLOBAL_TRANSLATION)];
+  return validateTranslations(translations, validators);
+};
 
-export { validate, validateTranslations };
+const validateNewGlobalTranslation = (translation: FormsApiGlobalTranslation): TranslationError | undefined => {
+  const validators: Validator[] = [
+    createMissingKeyValidator(),
+    createInputTooLongValidator(MAX_INPUT_LENGTH_GLOBAL_TRANSLATION, true),
+  ];
+  return validateTranslation(translation, validators);
+};
+
+export { validateFormTranslations, validateGlobalTranslations, validateNewGlobalTranslation };

--- a/packages/bygger/src/translations/components/TranslationInput.tsx
+++ b/packages/bygger/src/translations/components/TranslationInput.tsx
@@ -1,5 +1,5 @@
 import { Textarea, TextField } from '@navikt/ds-react';
-import { FocusEvent } from 'react';
+import { ChangeEvent } from 'react';
 import WysiwygEditor from '../../components/wysiwyg/WysiwygEditor';
 
 interface Props {
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const TranslationInput = ({ label, defaultValue, isHtml, minRows, onChange, error, autoFocus }: Props) => {
-  const handleBlur = (event: FocusEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     onChange(event.currentTarget.value);
   };
 
@@ -30,7 +30,7 @@ const TranslationInput = ({ label, defaultValue, isHtml, minRows, onChange, erro
         minRows={minRows}
         resize="vertical"
         defaultValue={defaultValue}
-        onBlur={handleBlur}
+        onChange={handleChange}
       />
     );
   }
@@ -41,7 +41,7 @@ const TranslationInput = ({ label, defaultValue, isHtml, minRows, onChange, erro
       label={label}
       hideLabel
       defaultValue={defaultValue}
-      onBlur={handleBlur}
+      onChange={handleChange}
     />
   );
 };

--- a/packages/bygger/src/translations/form/FormTranslationsPage.tsx
+++ b/packages/bygger/src/translations/form/FormTranslationsPage.tsx
@@ -48,7 +48,7 @@ const FormTranslationsPage = ({ form }: Props) => {
         </Title>
       </TitleRowLayout>
       <EditFormTranslationsProvider initialChanges={initialChanges}>
-        <form>
+        <form onSubmit={(event) => event.preventDefault()}>
           <RowLayout
             right={
               <SidebarLayout noScroll>

--- a/packages/bygger/src/translations/global/GlobalTranslationsPage.tsx
+++ b/packages/bygger/src/translations/global/GlobalTranslationsPage.tsx
@@ -41,7 +41,7 @@ const GlobalTranslationsPage = () => {
         <Title>{titles[tag]}</Title>
       </TitleRowLayout>
       <EditGlobalTranslationsProvider>
-        <form>
+        <form onSubmit={(event) => event.preventDefault()}>
           <RowLayout
             right={
               <SidebarLayout noScroll={true}>


### PR DESCRIPTION
- Fix GlobalTranslations cypress test
- Fix unecessary reload on submit (translation page)
- Get all recent changes on submit (translations)
- Adjust max length in input validation