### PR TITLE
Delete form - Do not emit message on success

### DIFF
--- a/packages/bygger/src/api/useFormsApiForms.ts
+++ b/packages/bygger/src/api/useFormsApiForms.ts
@@ -156,7 +156,6 @@ const useFormsApiForms = () => {
       });
       await http.delete(`${url}?${searchParams}`);
       logger?.debug(`Successfully deleted form with path ${form.path}: ${url}`);
-      feedbackEmit.success(`Skjemaet ble slettet`);
       return { success: true };
     } catch (error) {
       const message = (error as Error)?.message;


### PR DESCRIPTION
The user is redirected to main page where we do not show any messages to the user), but the message will be visible if another form is immediately opened, which is confusing.