### PR TITLE
Bug/erstatte tab med space

### DIFF
--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.test.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.test.ts
@@ -151,6 +151,26 @@ describe('feltMapBuilder', () => {
         expect(feltMapString).toContain('Field');
         expect(feltMapString).toContain('value');
       });
+
+      it('adds fields with value with tab', () => {
+        const verdiliste = createVerdilister([
+          createPanel('Panel', [
+            createContainer('Fieldset', 'fieldset', [createComponent('Field', 'value\n\twith tab')]),
+          ]),
+        ]);
+        const feltMap: FeltMap = {
+          label: 'title',
+          pdfConfig: { harInnholdsfortegnelse: false, språk: 'nb' },
+          skjemanummer: 'NAV 11-12.15B',
+          verdiliste: verdiliste,
+          bunntekst,
+        };
+
+        const feltMapString = JSON.stringify(feltMap).replace('\\t', '  ');
+        expect(feltMapString).toContain('Panel');
+        expect(feltMapString).toContain('Field');
+        expect(feltMapString).toContain('  with tab');
+      });
     });
 
     /* *** */

--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.test.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.test.ts
@@ -155,7 +155,13 @@ describe('feltMapBuilder', () => {
       it('adds fields with value with tab', () => {
         const verdiliste = createVerdilister([
           createPanel('Panel', [
-            createContainer('Fieldset', 'fieldset', [createComponent('Field', 'value\n\twith tab')]),
+            createContainer('Fieldset', 'fieldset', [
+              createComponent(
+                'Field',
+                'bruke etableringsperioden til å utvikle og konkretisere forretningsideen.\n\nPlanen for etableringsperioden er:\n1.\tStarte et FoU-prosjekt i samarbeid med et godkjent forsknings- og utviklingsmiljø.',
+              ),
+              createComponent('Field', 'etter etableringsperioden forfine produket.\n\tI samarbeid med FoU-miljø.'),
+            ]),
           ]),
         ]);
         const feltMap: FeltMap = {
@@ -166,10 +172,11 @@ describe('feltMapBuilder', () => {
           bunntekst,
         };
 
-        const feltMapString = JSON.stringify(feltMap).replace('\\t', '  ');
+        const feltMapString = JSON.stringify(feltMap).replaceAll('\\t', '  ');
         expect(feltMapString).toContain('Panel');
         expect(feltMapString).toContain('Field');
-        expect(feltMapString).toContain('  with tab');
+        expect(feltMapString).toContain('  Starte et FoU-prosjekt');
+        expect(feltMapString).toContain('  I samarbeid med');
       });
     });
 

--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
@@ -19,7 +19,6 @@ import {
   TEXTS,
 } from '@navikt/skjemadigitalisering-shared-domain';
 import { config } from '../../../config/config';
-import { logger } from '../../../logger';
 import { EkstraBunntekst, FeltMap, PdfConfig, VerdilisteElement } from '../../../types/familiepdf/feltMapTypes';
 
 type TranslateFunction = (text: string) => string;
@@ -73,9 +72,7 @@ export const createFeltMapFromSubmission = (
     bunntekst: ekstraBunntekst,
   };
 
-  const jsonString = JSON.stringify(feltMap).replaceAll('\\t', '  ');
-  logger.info('FeltMap: ' + jsonString);
-  return jsonString;
+  return JSON.stringify(feltMap).replaceAll('\\t', '  ');
 };
 
 const createConfirmationElement = (

--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
@@ -19,6 +19,7 @@ import {
   TEXTS,
 } from '@navikt/skjemadigitalisering-shared-domain';
 import { config } from '../../../config/config';
+import { logger } from '../../../logger';
 import { EkstraBunntekst, FeltMap, PdfConfig, VerdilisteElement } from '../../../types/familiepdf/feltMapTypes';
 
 type TranslateFunction = (text: string) => string;
@@ -72,7 +73,9 @@ export const createFeltMapFromSubmission = (
     bunntekst: ekstraBunntekst,
   };
 
-  return JSON.stringify(feltMap).replaceAll('\\t', '  ');
+  const jsonString = JSON.stringify(feltMap).replaceAll('\\t', '  ');
+  logger.info('FeltMap: ' + jsonString);
+  return jsonString;
 };
 
 const createConfirmationElement = (

--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
@@ -72,7 +72,7 @@ export const createFeltMapFromSubmission = (
     bunntekst: ekstraBunntekst,
   };
 
-  return JSON.stringify(feltMap).replace('\\t', '  ');
+  return JSON.stringify(feltMap).replaceAll('\\t', '  ');
 };
 
 const createConfirmationElement = (

--- a/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
+++ b/packages/fyllut-backend/src/routers/api/helpers/feltMapBuilder.ts
@@ -72,7 +72,7 @@ export const createFeltMapFromSubmission = (
     bunntekst: ekstraBunntekst,
   };
 
-  return JSON.stringify(feltMap);
+  return JSON.stringify(feltMap).replace('\\t', '  ');
 };
 
 const createConfirmationElement = (


### PR DESCRIPTION
Tekst med TAB fører til at generering av PDF med familie-pdf feiler. Erstatter alle forekomster av TAB med 2 mellomrom