### PR TITLE
fix: use pnpm deploy output for form-spec-api Docker image

### DIFF
--- a/docker/Dockerfile.form-spec-api
+++ b/docker/Dockerfile.form-spec-api
@@ -3,9 +3,9 @@ ENV NODE_ENV=production
 ARG git_sha
 
 WORKDIR /app
-COPY form-spec-api/dist server
-COPY form-spec-api/node_modules server/node_modules
+COPY .deploy/form-spec-api server
+COPY form-spec-api/dist server/dist
 
 ENV GIT_SHA=${git_sha}
 WORKDIR server
-CMD ["node", "server.mjs"]
+CMD ["node", "dist/server.mjs"]

--- a/packages/form-spec-api/package.json
+++ b/packages/form-spec-api/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "jsdom": "^28.1.0",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.19.0"
   },

--- a/packages/form-spec-api/package.json
+++ b/packages/form-spec-api/package.json
@@ -5,6 +5,9 @@
   "description": "Backend service exposing JSON Schema for form submissions",
   "main": "dist/server.mjs",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "start": "cross-env NODE_ENV=development vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@5.2.1)


### PR DESCRIPTION
## Problem
The deploy fails with:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'winston' imported from /app/server/server.mjs
```

## Root cause
The Dockerfile copied `form-spec-api/node_modules` directly, but in a pnpm monorepo those are symlinks into the shared store which break inside Docker.

## Fix
- **Dockerfile**: Use `pnpm deploy` output from `.deploy/form-spec-api` (properly resolved node_modules), matching the pattern used by bygger-backend and fyllut-backend.
- **package.json**: Added `"files": ["dist"]` so `pnpm deploy` only includes build output, matching other backend packages.