### PR TITLE
fix: deploy failure due to probes returning 401

### DIFF
--- a/packages/fyllut-backend/src/app.ts
+++ b/packages/fyllut-backend/src/app.ts
@@ -3,7 +3,6 @@ import cors from 'cors';
 import express, { NextFunction, Request, Response } from 'express';
 import mustacheExpress from 'mustache-express';
 import { checkConfigConsistency, config } from './config/config';
-import { NaisCluster } from './config/nais-cluster';
 import { buildDirectory } from './context';
 import { setupDeprecatedEndpoints } from './deprecatedEndpoints';
 import expressJsonMetricHandler from './middleware/expressJsonMetricHandler';
@@ -35,7 +34,7 @@ export const createApp = (setupDev: boolean = false) => {
 
   const fyllutRouter = express.Router();
 
-  if (config.naisClusterName === NaisCluster.DEV || setupDev) {
+  if (config.isDelingslenke || setupDev) {
     setupDevServer(app, fyllutRouter, config);
   }
 

--- a/packages/fyllut-backend/src/setup-dev-server.test.ts
+++ b/packages/fyllut-backend/src/setup-dev-server.test.ts
@@ -24,6 +24,9 @@ describe('Setup dev server', () => {
         { path: '/fyllut/internal/metrics', ip: IP_NAV, cookies: [], expectedHttpStatus: 200 },
         { path: '/fyllut/internal/isalive', ip: IP_NAV, cookies: [], expectedHttpStatus: 200 },
         { path: '/fyllut/internal/isready', ip: IP_NAV, cookies: [], expectedHttpStatus: 200 },
+        { path: '/fyllut/internal/metrics', ip: IP_EXTERNAL, cookies: [], expectedHttpStatus: 200 },
+        { path: '/fyllut/internal/isready', ip: IP_EXTERNAL, cookies: [], expectedHttpStatus: 200 },
+        { path: '/fyllut/internal/isalive', ip: IP_EXTERNAL, cookies: [], expectedHttpStatus: 200 },
       ];
 
       it.each(requests)('%j', async ({ path, ip, cookies, expectedHttpStatus }) => {

--- a/packages/fyllut-backend/src/setup-dev-server.ts
+++ b/packages/fyllut-backend/src/setup-dev-server.ts
@@ -8,6 +8,7 @@ const DEV_ACCESS_COOKIE = 'fyllut-dev-access';
 
 // 155.55.* is Navs public IP range. Also includes the private IP range used by our
 // internal network (10.*), and localhost. Takes the IPv6 prefix ::ffff: into account.
+// FIXME This ip range is probably not correct anymore
 const isNavIp = (ip: string) => /^(::ffff:)?(155\.55\.|10\.|127\.)/.test(ip);
 const isFormPath = (value: string) => /^\w*$/.test(value);
 
@@ -43,7 +44,10 @@ export const setupDevServer = (expressApp: Express, fyllutRouter: Router, config
   });
 
   expressApp.all(/^(?!.*\/(test\/login|api)).*$/, cookieParser(), (req: Request, res: Response, next: NextFunction) => {
-    if (isNavIp(req.ip || '') || req.cookies[DEV_ACCESS_COOKIE]) {
+    if (req.path.startsWith('/fyllut/internal/')) {
+      logger.debug('Allowing access to probes - urls containing /internal is blocked from external access');
+      return next();
+    } else if (isNavIp(req.ip || '') || req.cookies[DEV_ACCESS_COOKIE]) {
       logger.debug('Dev access is valid');
       return next();
     } else {


### PR DESCRIPTION
deploy failed because probes suddenly were invoked from unknown ip, decided to whitelist /internal since urls containing /internal is blocked from external access, so these invocations will not come from the internet via ekstern.dev.nav.no