### PR TITLE
feat: Enable attachment upload in Fyllut for all forms

### DIFF
--- a/packages/fyllut-backend/src/routers/api/send-inn-soknad.ts
+++ b/packages/fyllut-backend/src/routers/api/send-inn-soknad.ts
@@ -16,7 +16,7 @@ import {
   validateInnsendingsId,
 } from './helpers/sendInn';
 
-const { sendInnConfig, tempAttachmentUploadForms } = config;
+const { sendInnConfig } = config;
 const getErrorMessage = 'Kan ikke hente mellomlagret søknad.';
 const postErrorMessage = 'Kan ikke starte mellomlagring av søknaden.';
 const putErrorMessage = 'Kan ikke oppdatere mellomlagret søknad.';
@@ -214,9 +214,16 @@ const sendInnSoknad = {
 };
 
 const shouldUploadAttachmentsInFyllut = (soknad: SendInnSoknadBody) => {
+  const shouldUploadAttachmentsInFyllut = (soknad.vedleggsListe?.length || 0) === 0;
+  if (!shouldUploadAttachmentsInFyllut) {
+    logger.info(`${soknad.innsendingsId}: Attachment upload in Fyllut disabled, send-inn-frontend will be used`, {
+      skjemanummer: soknad.skjemanr,
+      attachmentsCount: soknad.vedleggsListe?.length,
+      formPath: soknad.skjemaPath,
+    });
+  }
   return {
-    shouldUploadAttachmentsInFyllut:
-      tempAttachmentUploadForms.includes(soknad.skjemaPath) && (soknad.vedleggsListe?.length || 0) === 0,
+    shouldUploadAttachmentsInFyllut,
   };
 };
 

--- a/packages/fyllut-backend/src/routers/api/testdata/mellomlagring.ts
+++ b/packages/fyllut-backend/src/routers/api/testdata/mellomlagring.ts
@@ -153,7 +153,7 @@ export const sendInnResponseBody = {
   status: 'Opprettet',
   vedleggsListe: [],
   kanLasteOppAnnet: true,
-  shouldUploadAttachmentsInFyllut: false,
+  shouldUploadAttachmentsInFyllut: true,
   fristForEttersendelse: 14,
   endretDato: '2023-08-24T11:28:51.854038+02:00',
 };
@@ -210,7 +210,7 @@ export const decodedResponseBody = {
   status: 'Opprettet',
   vedleggsListe: [],
   kanLasteOppAnnet: true,
-  shouldUploadAttachmentsInFyllut: false,
+  shouldUploadAttachmentsInFyllut: true,
   fristForEttersendelse: 14,
   endretDato: '2023-08-24T11:28:51.854038+02:00',
 };


### PR DESCRIPTION
Upload will still be handled in send-inn-frontend if the user already has started uploading files there on an application which has not been submitted yet.