### PR TITLE
fix: prevent race condition on SummaryPage when entering directly via…

### DIFF
--- a/mocks/mocks/data/innsending-api/mellomlagring/getTestMellomlagring-valid-extra-values.json
+++ b/mocks/mocks/data/innsending-api/mellomlagring/getTestMellomlagring-valid-extra-values.json
@@ -40,7 +40,33 @@
             "label": "På døra",
             "value": "paDora"
           }
-        }
+        },
+        "attachments": [
+          {
+            "attachmentId": "eijyzy",
+            "navId": "eijyzy",
+            "type": "default",
+            "value": "ettersender",
+            "title": "Oppmøtebekreftelse",
+            "files": []
+          },
+          {
+            "attachmentId": "e3dw1sg",
+            "navId": "e3dw1sg",
+            "type": "default",
+            "value": "ettersender",
+            "title": "Bekreftelse på at du av helsemessige årsaker må benytte dyrere transport",
+            "files": []
+          },
+          {
+            "attachmentId": "em26fir",
+            "navId": "em26fir",
+            "type": "other",
+            "value": "nei",
+            "title": "Annet",
+            "files": []
+          }
+        ]
       }
     },
     "propertyNavn": null,

--- a/mocks/mocks/data/innsending-api/mellomlagring/nav083591/complete.json
+++ b/mocks/mocks/data/innsending-api/mellomlagring/nav083591/complete.json
@@ -110,24 +110,7 @@
   },
   "innsendingsId": "2db25aab-3524-4426-a333-489542bf16bf",
   "status": "Opprettet",
-  "vedleggsListe": [
-    {
-      "vedleggsnr": "L2",
-      "tittel": "Personinntektsskjema",
-      "label": "Personinntektsskjema",
-      "pakrevd": true,
-      "beskrivelse": "",
-      "formioId": "eiaivlp"
-    },
-    {
-      "vedleggsnr": "L2",
-      "tittel": "Resultatregnskap",
-      "label": "Resultatregnskap",
-      "pakrevd": true,
-      "beskrivelse": "",
-      "formioId": "etpewjh"
-    }
-  ],
+  "vedleggsListe": [],
   "kanLasteOppAnnet": true,
   "fristForEttersendelse": 14,
   "endretDato": "2024-02-15T10:26:31.152815+01:00",

--- a/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
+++ b/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
@@ -379,6 +379,42 @@ describe('Mellomlagring', () => {
           cy.wait('@updateMellomlagring');
           cy.findByText(TEXTS.statiske.mellomlagringError.update.message).should('be.visible');
         });
+
+        it('shows loading state and submits correctly when entering directly on summary page', () => {
+          const innsendingsId = '8e3c3621-76d7-4ebd-90d4-34448ebcccc3';
+
+          // Override mellomlagring intercept with a delayed response to make the race deterministic
+          cy.intercept('GET', `/fyllut/api/send-inn/soknad/${innsendingsId}`, (req) => {
+            req.continue((res) => {
+              res.setDelay(500);
+            });
+          }).as('getMellomlagringDelayed');
+
+          // Visit summary page directly (simulates opening a temporarily stored application)
+          cy.visit(`/fyllut/testmellomlagring/oppsummering?sub=digital&innsendingsId=${innsendingsId}&lang=nb-NO`);
+          cy.defaultWaits();
+
+          // While mellomlagring is loading, the loading state should be visible
+          cy.findByRole('heading', { name: 'Laster' }).should('be.visible');
+
+          // Wait for delayed mellomlagring response
+          cy.wait('@getMellomlagringDelayed');
+
+          // Verify summary page renders with correct submission data
+          cy.findByRole('heading', { name: TEXTS.statiske.summaryPage.title }).should('exist');
+          cy.findByText('Ønsker du å få gaven innpakket').should('exist').next('dd').should('contain.text', 'Nei');
+
+          // Submit the application
+          cy.clickSendNav();
+          cy.wait('@submitApplication').then((interception) => {
+            const { pdfFormData } = interception.request.body;
+            // Verify pdfFormData contains actual form content (not empty due to race condition)
+            expect(pdfFormData.verdiliste).to.have.length.greaterThan(0);
+            expect(pdfFormData.verdiliste[0]).to.have.property('label', 'Gave');
+          });
+
+          cy.findByRole('heading', { name: 'Kvittering' }).should('exist');
+        });
       });
 
       describe('When stored submission contains values for inputs that have been removed from the form', () => {

--- a/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
+++ b/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
@@ -18,7 +18,9 @@ const testMellomlagringConfirmationModal = (
   cy.findByRole('button', { name: buttonText }).click();
   cy.findByText(modalTexts.body).should('be.visible');
   cy.findByRole('button', { name: modalTexts.cancel }).click();
+  cy.get('dialog[open]').should('not.exist');
   cy.findByRole('button', { name: buttonText }).click();
+  cy.findByText(modalTexts.body).should('be.visible');
   cy.findByRole('button', { name: modalTexts.confirm }).click();
 };
 
@@ -123,6 +125,21 @@ describe('Mellomlagring', () => {
       cy.wait('@updateMellomlagring');
       cy.clickSaveAndContinue();
       cy.wait('@updateMellomlagring');
+
+      // Attachment page (shown for digital forms with attachment components)
+      cy.findByRole('heading', { name: TEXTS.statiske.attachment.title }).should('exist');
+      cy.findByRole('group', { name: /Annen dokumentasjon/ }).within(() => {
+        cy.findByLabelText(/Nei, jeg har ingen ekstra dokumentasjon/).check();
+      });
+      cy.findByRole('group', { name: /Oppmøtebekreftelse/ }).within(() => {
+        cy.findByLabelText(/ettersender dokumentasjonen senere/).check();
+      });
+      cy.findByRole('group', { name: /Bekreftelse på at du av helsemessige/ }).within(() => {
+        cy.findByLabelText(/ettersender dokumentasjonen senere/).check();
+      });
+      cy.clickSaveAndContinue();
+      cy.wait('@updateMellomlagring');
+
       cy.findByRole('button', { name: TEXTS.grensesnitt.navigation.saveDraft }).should('exist');
       cy.findByRole('button', { name: TEXTS.grensesnitt.navigation.cancelAndDelete }).should('exist');
     });
@@ -286,7 +303,9 @@ describe('Mellomlagring', () => {
 
           cy.clickEditAnswers();
           cy.url().should('include', '/levering');
-          cy.findByRole('combobox', { name: 'Hvordan ønsker du å motta pakken?' }).should('have.focus');
+          cy.findByRole('combobox', { name: 'Hvordan ønsker du å motta pakken?' })
+            .should('be.visible')
+            .should('have.focus');
         });
 
         it('lets you edit and update submission data', () => {
@@ -596,8 +615,8 @@ describe('Mellomlagring', () => {
           const { submission } = req.body;
           expect(submission.data.landvelger).to.deep.eq({ label: 'Frankrike', value: 'FR' });
           expect(submission.attachments).to.have.length(3);
-          expect(submission.attachments[0].label).to.eq('Personinntektsskjema');
-          expect(submission.attachments[1].label).to.eq('Resultatregnskap');
+          expect(submission.attachments[0].title).to.eq('Personinntektsskjema');
+          expect(submission.attachments[1].title).to.eq('Resultatregnskap');
         });
         cy.intercept('GET', '/fyllut/api/send-inn/soknad/2db25aab-3524-4426-a333-489542bf16bf').as('getMellomlagring');
 

--- a/packages/shared-components/src/context/form/FormContext.tsx
+++ b/packages/shared-components/src/context/form/FormContext.tsx
@@ -34,12 +34,16 @@ const FormContext = createContext<FormContextType>({} as FormContextType);
 
 export const FormProvider = ({ children, form }: FormProviderProps) => {
   const [submission, setSubmission] = useState<Submission>();
-  const [activeComponents, setActiveComponents] = useState<Component[]>([]);
   const [formProgressOpen, setFormProgressOpen] = useState<boolean>(false);
   const [formProgressVisible, setFormProgressVisible] = useState<boolean>(false);
   const [prefillData, setPrefillData] = useState<PrefillData>({});
   const [title, setTitle] = useState<string | undefined>();
-  const { attachmentPageEnabled, http, baseUrl, submissionMethod, logger } = useAppConfig();
+  const { attachmentPageEnabled, http, baseUrl, submissionMethod } = useAppConfig();
+
+  const activeComponents = useMemo(
+    () => navFormUtils.getActiveComponentsFromForm(form, submission),
+    [form, submission],
+  );
 
   const activeAttachmentUploadsPanel = useMemo(() => {
     const activeAttachmentPanel = attachmentPageEnabled
@@ -98,13 +102,6 @@ export const FormProvider = ({ children, form }: FormProviderProps) => {
       loadPrefillData(form);
     }
   }, [baseUrl, form, http, submissionMethod]);
-
-  useEffect(() => {
-    const currentActiveComponents = navFormUtils.getActiveComponentsFromForm(form, submission);
-    logger?.debug('Current active components', { form, currentActiveComponents });
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setActiveComponents(currentActiveComponents);
-  }, [form, logger, submission]);
 
   return (
     <FormContext.Provider

--- a/packages/shared-components/src/pages/summary/SummaryPage.tsx
+++ b/packages/shared-components/src/pages/summary/SummaryPage.tsx
@@ -14,10 +14,12 @@ import { attachmentValidator } from '../../components/attachment/attachmentValid
 import ButtonRow from '../../components/button/ButtonRow';
 import EditAnswersButton from '../../components/button/navigation/edit-answers/EditAnswersButton';
 import ValidationExclamationIcon from '../../components/icons/ValidationExclamationIcon';
+import LoadingComponent from '../../components/loading/LoadingComponent';
 import NavFormHelper from '../../components/nav-form/NavFormHelper';
 import { useAppConfig } from '../../context/config/configContext';
 import { useForm } from '../../context/form/FormContext';
 import { useLanguages } from '../../context/languages';
+import { useSendInn } from '../../context/sendInn/sendInnContext';
 import RenderSummaryForm from '../../form-components/RenderSummaryForm';
 import { scrollToAndSetFocus } from '../../util/focus-management/focus-management';
 import {
@@ -39,12 +41,16 @@ export function SummaryPage() {
     activeComponents,
     activeAttachmentUploadsPanel,
   } = useForm();
+  const { isMellomlagringAvailable, isMellomlagringReady, mellomlagringError } = useSendInn();
   const { declarationType, declarationText } = form.properties;
   const [declaration, setDeclaration] = useState<boolean | undefined>(undefined);
 
   const [panelValidationList, setPanelValidationList] = useState<PanelValidation[] | undefined>();
+  const isMellomlagringLoading = isMellomlagringAvailable && !isMellomlagringReady && !mellomlagringError;
 
   useEffect(() => {
+    if (isMellomlagringLoading) return;
+
     const initializePanelValidation = async () => {
       const submissionCopy: Submission = JSON.parse(JSON.stringify(submission || {}));
 
@@ -100,7 +106,7 @@ export function SummaryPage() {
     if (availableLanguages.length > 0) {
       initializePanelValidation();
     }
-  }, [form, submission, appConfig, prefillData, translate, availableLanguages]);
+  }, [form, submission, appConfig, prefillData, translate, availableLanguages, isMellomlagringLoading]);
 
   useEffect(() => {
     setTitle(TEXTS.statiske.summaryPage.title);
@@ -127,6 +133,10 @@ export function SummaryPage() {
   };
 
   const hasValidationErrors = panelValidationList?.some((panelValidation) => panelValidation.hasValidationErrors);
+
+  if (isMellomlagringLoading) {
+    return <LoadingComponent heightOffsetRem={18} />;
+  }
 
   return (
     <VStack gap="space-32">


### PR DESCRIPTION
… mellomlagring URL

When a user opens a temporarily stored application directly on the summary page (e.g. /fyllut/nav123456/oppsummering?sub=digital&innsendingsId=XXXX), the mellomlagring data is fetched asynchronously. Two issues caused submission to proceed before data was ready:

1. SummaryPage lacked the mellomlagring loading guard that FillInFormPage and IntroPage already have. This allowed rendering and interaction before submission data was loaded.

2. activeComponents in FormContext was computed via useEffect + setState, introducing a one-render delay. When submission was set, the next render still had activeComponents=[], causing pdfFormData to be generated with empty form content.

Fix:
- Add isMellomlagringReady loading guard to SummaryPage (matching existing guards in FillInFormPage and IntroPage)
- Replace useEffect with useMemo for activeComponents so it updates synchronously with submission state
- Add deterministic Cypress test that simulates direct summary page entry with a delayed mellomlagring response