### PR TITLE
refactor: attachment page state to stabilize cypress tests

### DIFF
--- a/mocks/mocks/data/innsending-api/mellomlagring/getTestMellomlagring-valid-1-sendinn-upload.json
+++ b/mocks/mocks/data/innsending-api/mellomlagring/getTestMellomlagring-valid-1-sendinn-upload.json
@@ -1,0 +1,64 @@
+{
+  "brukerId": "19876898104",
+  "skjemanr": "testMellomlagring",
+  "tittel": "Test mellomlagring",
+  "tema": "BAR",
+  "spraak": "nb",
+  "hoveddokument": {
+    "vedleggsnr": "testMellomlagring",
+    "tittel": "Test mellomlagring",
+    "label": "Test mellomlagring",
+    "pakrevd": true,
+    "beskrivelse": null,
+    "mimetype": "application/pdf",
+    "document": null,
+    "propertyNavn": null,
+    "formioId": null
+  },
+  "hoveddokumentVariant": {
+    "vedleggsnr": "testMellomlagring",
+    "tittel": "Test mellomlagring",
+    "label": "Test mellomlagring",
+    "pakrevd": false,
+    "beskrivelse": null,
+    "mimetype": "application/json",
+    "document": {
+      "language": "nb-NO",
+      "data": {
+        "data": {
+          "dineOpplysninger": {
+            "identitet": {
+              "identitetsnummer": "03876399856"
+            }
+          },
+          "hvaDrakkDuTilFrokost": "",
+          "hvaSpisteDuTilFrokost": "",
+          "onskerDuAFaGavenInnpakket": "nei",
+          "hemmeligKode": "",
+          "kryssAvHvisDuOnskerDagligReklamePaEPost": false,
+          "hvordanOnskerDuAMottaPakken": {
+            "label": "På døra",
+            "value": "paDora"
+          }
+        }
+      }
+    },
+    "propertyNavn": null,
+    "formioId": null
+  },
+  "innsendingsId": "8e3c3621-76d7-4ebd-90d4-34448ebcccc3",
+  "status": "Opprettet",
+  "vedleggsListe": [
+    {
+      "vedleggsnr": "N6",
+      "tittel": "Annet",
+      "label": "Min fil",
+      "pakrevd": false,
+      "beskrivelse": ""
+    }
+  ],
+  "kanLasteOppAnnet": true,
+  "fristForEttersendelse": 14,
+  "endretDato": "2023-08-30T12:33:30.399543+02:00",
+  "skalSlettesDato": "2024-01-10"
+}

--- a/mocks/mocks/routes/innsending-api.ts
+++ b/mocks/mocks/routes/innsending-api.ts
@@ -18,6 +18,7 @@ import formSelectSoknadCompleteV1 from '../data/innsending-api/mellomlagring/for
 import formSelectSoknadInvalidCountryV1 from '../data/innsending-api/mellomlagring/form-select/saved-invalid-country-v1.json';
 import formSelectSoknadInvalidInstrumentV1 from '../data/innsending-api/mellomlagring/form-select/saved-invalid-instrument-v2.json';
 import formSelectSoknadPartialV1 from '../data/innsending-api/mellomlagring/form-select/saved-partial-v1.json';
+import mellomlagringValid1SendinnUpload from '../data/innsending-api/mellomlagring/getTestMellomlagring-valid-1-sendinn-upload.json';
 import mellomlagringValid1 from '../data/innsending-api/mellomlagring/getTestMellomlagring-valid-1.json';
 import mellomlagringValid2 from '../data/innsending-api/mellomlagring/getTestMellomlagring-valid-2.json';
 import mellomlagringValidExtraValues from '../data/innsending-api/mellomlagring/getTestMellomlagring-valid-extra-values.json';
@@ -200,6 +201,14 @@ export default [
         options: {
           status: 200,
           body: convertToInnsendingApiResponse(mellomlagringValid1),
+        },
+      },
+      {
+        id: 'success-1-sendinn-upload',
+        type: 'json',
+        options: {
+          status: 200,
+          body: convertToInnsendingApiResponse(mellomlagringValid1SendinnUpload),
         },
       },
       {

--- a/packages/form-spec-api/src/routers/api/index.test.ts
+++ b/packages/form-spec-api/src/routers/api/index.test.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const TEST_TIMEOUT_MS = 10_000;
+
 const m2mHandler = vi.fn((_, res, next) => {
   res.set('x-auth-handler', 'm2m');
   next();
@@ -36,29 +38,37 @@ describe('apiRouter auth wiring', () => {
     oboHandler.mockClear();
   });
 
-  it('uses the M2M handler for /forms routes', async () => {
-    const { default: apiRouter } = await import('./index');
-    const app = express();
+  it(
+    'uses the M2M handler for /forms routes',
+    async () => {
+      const { default: apiRouter } = await import('./index');
+      const app = express();
 
-    app.use('/api', apiRouter);
+      app.use('/api', apiRouter);
 
-    const response = await request(app).get('/api/forms/nav123456/spec').expect(204);
+      const response = await request(app).get('/api/forms/nav123456/spec').expect(204);
 
-    expect(response.header['x-auth-handler']).toBe('m2m');
-    expect(m2mHandler).toHaveBeenCalledTimes(1);
-    expect(oboHandler).not.toHaveBeenCalled();
-  });
+      expect(response.header['x-auth-handler']).toBe('m2m');
+      expect(m2mHandler).toHaveBeenCalledTimes(1);
+      expect(oboHandler).not.toHaveBeenCalled();
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-  it('uses the OBO handler for /employee/forms routes', async () => {
-    const { default: apiRouter } = await import('./index');
-    const app = express();
+  it(
+    'uses the OBO handler for /employee/forms routes',
+    async () => {
+      const { default: apiRouter } = await import('./index');
+      const app = express();
 
-    app.use('/api', apiRouter);
+      app.use('/api', apiRouter);
 
-    const response = await request(app).get('/api/employee/forms/nav123456/spec').expect(204);
+      const response = await request(app).get('/api/employee/forms/nav123456/spec').expect(204);
 
-    expect(response.header['x-auth-handler']).toBe('obo');
-    expect(oboHandler).toHaveBeenCalledTimes(1);
-    expect(m2mHandler).not.toHaveBeenCalled();
-  });
+      expect(response.header['x-auth-handler']).toBe('obo');
+      expect(oboHandler).toHaveBeenCalledTimes(1);
+      expect(m2mHandler).not.toHaveBeenCalled();
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
+++ b/packages/fyllut/cypress/e2e/digital-submission/mellomlagring.cy.ts
@@ -269,7 +269,6 @@ describe('Mellomlagring', () => {
         });
 
         it('retrieves mellomlagring and redirects after submitting', () => {
-          // fails
           cy.visit(
             '/fyllut/testmellomlagring?sub=digital&innsendingsId=8e3c3621-76d7-4ebd-90d4-34448ebcccc3&lang=nb-NO',
           );
@@ -306,6 +305,33 @@ describe('Mellomlagring', () => {
           cy.findByRole('combobox', { name: 'Hvordan ønsker du å motta pakken?' })
             .should('be.visible')
             .should('have.focus');
+        });
+
+        describe('retrieves mellomlagring containing vedleggsliste', () => {
+          it('shows attachment page when empty', () => {
+            cy.visit(
+              '/fyllut/testmellomlagring/oppsummering?sub=digital&innsendingsId=8e3c3621-76d7-4ebd-90d4-34448ebcccc3&lang=nb-NO',
+            );
+            cy.defaultWaits();
+            cy.wait('@getMellomlagringValid');
+            cy.findByRole('heading', { name: TEXTS.statiske.summaryPage.title }).should('exist');
+
+            cy.clickShowAllSteps();
+            cy.findByRole('link', { name: 'Vedlegg' }).should('exist');
+          });
+
+          it('hides attachment page when not empty', () => {
+            cy.mocksUseRouteVariant('get-soknad:success-1-sendinn-upload');
+            cy.visit(
+              '/fyllut/testmellomlagring/oppsummering?sub=digital&innsendingsId=8e3c3621-76d7-4ebd-90d4-34448ebcccc3&lang=nb-NO',
+            );
+            cy.defaultWaits();
+            cy.wait('@getMellomlagringValid');
+            cy.findByRole('heading', { name: TEXTS.statiske.summaryPage.title }).should('exist');
+
+            cy.clickShowAllSteps();
+            cy.findByRole('link', { name: 'Vedlegg' }).should('not.exist');
+          });
         });
 
         it('lets you edit and update submission data', () => {

--- a/packages/shared-components/src/context/config/configContext.tsx
+++ b/packages/shared-components/src/context/config/configContext.tsx
@@ -54,7 +54,7 @@ function AppConfigProvider({
   }, [app, config, logger]);
 
   const [internalDiffOn, setDiffOn] = useState<boolean>(diffOn!);
-  const [attachmentPageEnabled, setAttachmentPageEnabled] = useState<boolean>(submissionMethod !== 'digital');
+  const [attachmentPageEnabled, setAttachmentPageEnabled] = useState<boolean>(true);
   return (
     <AppConfigContext.Provider
       value={{

--- a/packages/shared-components/src/context/sendInn/sendInnContext.test.tsx
+++ b/packages/shared-components/src/context/sendInn/sendInnContext.test.tsx
@@ -1,9 +1,10 @@
 import { NavFormType, Submission } from '@navikt/skjemadigitalisering-shared-domain';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router';
 import { vi } from 'vitest';
-import { http } from '../../index';
+import { http, useAppConfig } from '../../index';
 import { AppConfigProvider } from '../config/configContext';
 import { FormProvider } from '../form/FormContext';
 import { SendInnProvider, useSendInn } from './sendInnContext';
@@ -24,7 +25,11 @@ const mockHttp = {
 
 describe('sendInnContext', () => {
   const TestComponent = ({ submission }) => {
+    const { setAttachmentPageEnabled } = useAppConfig();
     const { updateMellomlagring, deleteMellomlagring, submitSoknad, innsendingsId } = useSendInn();
+    useEffect(() => {
+      setAttachmentPageEnabled?.(false);
+    }, [setAttachmentPageEnabled]);
 
     return (
       <>

--- a/packages/shared-components/src/context/sendInn/sendInnContext.tsx
+++ b/packages/shared-components/src/context/sendInn/sendInnContext.tsx
@@ -124,8 +124,8 @@ const SendInnProvider = ({ children }: SendInnProviderProps) => {
   const retrieveMellomlagring = useCallback(
     async (innsendingsId: string) => {
       const response = await getSoknad(innsendingsId, appConfig);
-      if (response?.shouldUploadAttachmentsInFyllut && setAttachmentPageEnabled) {
-        setAttachmentPageEnabled(true);
+      if (!response?.shouldUploadAttachmentsInFyllut && setAttachmentPageEnabled) {
+        setAttachmentPageEnabled(false);
       }
       if (response?.hoveddokumentVariant.document) {
         addSearchParamToUrl('lang', response.hoveddokumentVariant.document.language);
@@ -186,9 +186,6 @@ const SendInnProvider = ({ children }: SendInnProviderProps) => {
         setInnsendingsId(response?.innsendingsId);
         removeSearchParamFromUrl('forceMellomlagring');
         addSearchParamToUrl('innsendingsId', response?.innsendingsId);
-        if (response?.shouldUploadAttachmentsInFyllut && setAttachmentPageEnabled) {
-          setAttachmentPageEnabled(true);
-        }
         if (response) {
           setIsMellomlagringReady(true);
         }
@@ -208,7 +205,6 @@ const SendInnProvider = ({ children }: SendInnProviderProps) => {
       logger,
       setSubmission,
       removeSearchParamFromUrl,
-      setAttachmentPageEnabled,
       addSearchParamToUrl,
       navigate,
     ],
@@ -454,6 +450,7 @@ const SendInnProvider = ({ children }: SendInnProviderProps) => {
   }, [form, logEvent, logger, navigate, setSubmission, submissionMethod, translate]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setTokenDetails(tokenUtils.parseToken(nologinToken));
   }, [nologinToken]);
 
@@ -467,6 +464,7 @@ const SendInnProvider = ({ children }: SendInnProviderProps) => {
       }, msUntilExp);
       return () => clearTimeout(timeoutId);
     } else {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       handleSessionExpired();
     }
   }, [tokenDetails, handleSessionExpired]);


### PR DESCRIPTION
since attachments mostly is uploaded in Fyllut now we make that the standard setting, which will reduce the number of state changes and subsequent rerenders, hopefully stabilizing the cypress tests.