### PR TITLE
Improve start script port check for IPv4 and IPv6 loopback

### DIFF
--- a/bin/start.mjs
+++ b/bin/start.mjs
@@ -37,22 +37,36 @@ const isPortFree = (port) =>
     server.listen(port);
   });
 
+const loopbackHosts = ['127.0.0.1', '::1'];
+
+const canConnect = (port, host) =>
+  new Promise((resolve) => {
+    const socket = connect(port, host);
+    const done = (connected) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(connected);
+    };
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+  });
+
 const waitForPort = (port, timeout = 60000) =>
   new Promise((resolve, reject) => {
     const start = Date.now();
-    const attempt = () => {
-      const socket = connect(port, '127.0.0.1');
-      socket.once('connect', () => {
-        socket.destroy();
+    const attempt = async () => {
+      const checks = await Promise.all(loopbackHosts.map((host) => canConnect(port, host)));
+      if (checks.some(Boolean)) {
         resolve();
-      });
-      socket.once('error', () => {
-        socket.destroy();
-        if (Date.now() - start > timeout) return reject(new Error(`Port ${port} not ready after ${timeout}ms`));
-        setTimeout(attempt, 250);
-      });
+        return;
+      }
+      if (Date.now() - start > timeout) {
+        reject(new Error(`Port ${port} not ready after ${timeout}ms`));
+        return;
+      }
+      setTimeout(() => void attempt(), 250);
     };
-    attempt();
+    void attempt();
   });
 
 const getFreePorts = async (count, start = 3440) => {


### PR DESCRIPTION
The `waitForPort` function now attempts to connect to both `127.0.0.1` (IPv4) and `::1` (IPv6) loopback addresses.

This enhances the reliability and compatibility of the start script by ensuring it can detect services listening on either loopback interface, especially in environments like Windows where services may bind to the IPv6 loopback address by default.