### PR TITLE
fix: cypress tests in group 'form'

### DIFF
--- a/packages/fyllut/src/components/form/FormPageWrapper.tsx
+++ b/packages/fyllut/src/components/form/FormPageWrapper.tsx
@@ -18,6 +18,7 @@ import {
   applyPrefilledValuesToSubmission,
   buildDigitalFormSearch,
   isSoknadAlreadyExistsResponse,
+  resolveDefaultSubmissionMethod,
   shouldUseLegacyPageForNewRenderer,
 } from '@navikt/skjemadigitalisering-shared-frontend';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -31,8 +32,6 @@ import RenderFormAdapter from './RenderFormAdapter';
 
 const DELETED_DRAFT_STORAGE_KEY = 'fyllut:new-render:deleted-draft-id';
 const DELETED_DRAFT_QUERY_PARAM = 'deletedDraft';
-const DEFAULT_SUBMISSION_METHOD = 'paper';
-
 const collectPrefillKeys = (components: Component[] = []): string[] =>
   components.flatMap((component) => [
     ...(Array.isArray(component.prefillKey)
@@ -128,22 +127,30 @@ const FormPageWrapper = () => {
     !!formPath && ((config?.newRenderForms ?? []).includes('*') || (config?.newRenderForms ?? []).includes(formPath));
   const useLegacyPageForNewRenderer = shouldUseLegacyPageForNewRenderer(routePath);
   const navForm = useMemo(() => (form ? formioFormsApiUtils.mapFormToNavForm(form) : undefined), [form]);
+  const defaultRouteSubmissionMethod = useMemo(
+    () => (form ? resolveDefaultSubmissionMethod(form.properties.submissionTypes) : undefined),
+    [form],
+  );
   const dataKey = `${formPath ?? ''}|${getDraftBootstrapLanguage(search)}|${submissionMethod ?? ''}`;
   const missingSubmissionMethodOnDirectRoute =
-    useNewRenderer && !useLegacyPageForNewRenderer && !!routePath && !new URLSearchParams(search).has('sub');
+    useNewRenderer &&
+    !useLegacyPageForNewRenderer &&
+    !!routePath &&
+    !new URLSearchParams(search).has('sub') &&
+    defaultRouteSubmissionMethod === 'paper';
 
   useEffect(() => {
-    if (!missingSubmissionMethodOnDirectRoute) {
+    if (!missingSubmissionMethodOnDirectRoute || !defaultRouteSubmissionMethod) {
       return;
     }
 
     navigate(
       {
-        search: buildSearchWithSubmissionMethod(search, DEFAULT_SUBMISSION_METHOD),
+        search: buildSearchWithSubmissionMethod(search, defaultRouteSubmissionMethod),
       },
       { replace: true },
     );
-  }, [missingSubmissionMethodOnDirectRoute, navigate, search]);
+  }, [defaultRouteSubmissionMethod, missingSubmissionMethodOnDirectRoute, navigate, search]);
 
   useEffect(() => {
     stateInitialSubmissionRef.current =

--- a/packages/shared-frontend/src/form-components/RenderInputComponent.tsx
+++ b/packages/shared-frontend/src/form-components/RenderInputComponent.tsx
@@ -28,8 +28,12 @@ const RenderInputComponent = ({ component, submissionPath, componentRegistry = i
     return null;
   }
 
+  const formioClasses = [`formio-component-${component.key}`, `formio-component-${component.type}`]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className={`formio-component-${component.key}`}>
+    <div className={formioClasses}>
       <RegistryComponent component={component} submissionPath={submissionPath} componentRegistry={componentRegistry} />
     </div>
   );

--- a/packages/shared-frontend/src/form-components/components/data-grid/InputDataGrid.test.ts
+++ b/packages/shared-frontend/src/form-components/components/data-grid/InputDataGrid.test.ts
@@ -126,6 +126,57 @@ describe('InputDataGrid helpers', () => {
     ).toEqual(['showField', 'field']);
   });
 
+  it('filters nested custom conditionals against the nearest container row data', () => {
+    const datagrid: Component = {
+      key: 'kjaeledyr',
+      label: 'Kjaeledyr',
+      type: 'datagrid',
+      navId: 'grid',
+      components: [
+        {
+          key: 'egenskaper',
+          label: 'Egenskaper',
+          type: 'container',
+          input: true,
+          tree: true,
+          navId: 'container',
+          components: [
+            { key: 'alder', label: 'Alder', type: 'textfield', navId: 'alder' },
+            {
+              key: 'brukerDyretMedisiner',
+              label: 'Bruker dyret medisiner?',
+              type: 'radiopanel',
+              navId: 'medisiner',
+              customConditional: 'show = row.alder ? parseInt(row.alder) >= 10 : false;',
+            },
+          ],
+        },
+      ],
+    };
+    const form = createForm([datagrid]);
+    const rowComponents = enrichComponentsWithBaseSubmissionPath(datagrid.components ?? [], 'kjaeledyr[0]');
+
+    const hidden = getActiveRowComponents(
+      rowComponents,
+      { egenskaper: { alder: '9' } },
+      { kjaeledyr: [{ egenskaper: { alder: '9' } }] },
+      form,
+    );
+    expect(
+      hidden.find((component) => component.key === 'egenskaper')?.components?.map((component) => component.key),
+    ).toEqual(['alder']);
+
+    const visible = getActiveRowComponents(
+      rowComponents,
+      { egenskaper: { alder: '10' } },
+      { kjaeledyr: [{ egenskaper: { alder: '10' } }] },
+      form,
+    );
+    expect(
+      visible.find((component) => component.key === 'egenskaper')?.components?.map((component) => component.key),
+    ).toEqual(['alder', 'brukerDyretMedisiner']);
+  });
+
   it('filters selectboxes-based custom conditionals against row data', () => {
     const datagrid: Component = {
       key: 'maltider',

--- a/packages/shared-frontend/src/form-components/components/data-grid/InputDataGrid.tsx
+++ b/packages/shared-frontend/src/form-components/components/data-grid/InputDataGrid.tsx
@@ -135,9 +135,24 @@ const getActiveRowComponents = (
       component.components?.length
         ? {
             ...component,
-            components: getActiveRowComponents(component.components, row, data, form),
+            components: getActiveRowComponents(component.components, getChildRow(component, row), data, form),
           }
         : component,
     );
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const shouldScopeChildRow = (component: Component) => Boolean(component.key && (component.tree || component.input));
+
+const getChildRow = (component: Component, row: object | undefined) => {
+  if (!shouldScopeChildRow(component) || !isObjectRecord(row)) {
+    return row;
+  }
+
+  const childRow = row[component.key];
+  return isObjectRecord(childRow) ? childRow : row;
+};
+
 export default InputDataGrid;
 export { getActiveRowComponents, getRenderedDataGridRows };

--- a/packages/shared-frontend/src/form/FormLanguageSelector.tsx
+++ b/packages/shared-frontend/src/form/FormLanguageSelector.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useFyllutLanguage } from '../context/fyllut/FyllutLanguageContext';
+import { useSubmissionState } from '../context/state/SubmissionStateContext';
 
 const languagesInOriginalLanguage: Record<string, string> = {
   'nb-NO': 'Norsk bokmål',
@@ -22,7 +23,9 @@ const persistStepperOpenStateForReload = () => {
 
 const FormLanguageSelector = () => {
   const { currentLanguage, availableLanguages } = useFyllutLanguage();
-  const { pathname, search } = useLocation();
+  const { submission } = useSubmissionState();
+  const { pathname, search, state } = useLocation();
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
   const supportedLanguages = useMemo(() => {
@@ -54,6 +57,17 @@ const FormLanguageSelector = () => {
   }
 
   const label = languagesInOriginalLanguage[currentLanguage] ?? 'Norsk bokmål';
+  const navigationState =
+    typeof state === 'object' && state
+      ? {
+          ...state,
+          initialSubmission: submission,
+          preserveInitialSubmission: true as const,
+        }
+      : {
+          initialSubmission: submission,
+          preserveInitialSubmission: true as const,
+        };
 
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '1rem', position: 'relative' }}>
@@ -77,7 +91,21 @@ const FormLanguageSelector = () => {
             }}
           >
             {options.map((option) => (
-              <a key={option.href} href={option.href} onClick={persistStepperOpenStateForReload}>
+              <a
+                key={option.href}
+                href={option.href}
+                onClick={(event) => {
+                  event.preventDefault();
+                  persistStepperOpenStateForReload();
+                  navigate(
+                    {
+                      pathname,
+                      search: new URL(option.href, window.location.origin).search,
+                    },
+                    { state: navigationState },
+                  );
+                }}
+              >
                 {option.label}
               </a>
             ))}

--- a/packages/shared-frontend/src/form/FormSecondaryButtons.tsx
+++ b/packages/shared-frontend/src/form/FormSecondaryButtons.tsx
@@ -17,6 +17,7 @@ interface Props {
 
 const DELETED_DRAFT_STORAGE_KEY = 'fyllut:new-render:deleted-draft-id';
 const DELETED_DRAFT_QUERY_PARAM = 'deletedDraft';
+const DISCARDED_SUBMISSION_STORAGE_KEY = 'fyllut:new-render:discarded-submission';
 
 const FormSecondaryButtons = ({ introUploadIdLink = false, exitOnly = false }: Props) => {
   const appConfig = useFyllutAppConfig();
@@ -57,6 +58,11 @@ const FormSecondaryButtons = ({ introUploadIdLink = false, exitOnly = false }: P
     setCancelModalOpen(false);
   };
 
+  const handleExit = () => {
+    sessionStorage.setItem(DISCARDED_SUBMISSION_STORAGE_KEY, '1');
+    setSubmission(undefined);
+  };
+
   return (
     <>
       <Box marginBlock="space-16 space-0">
@@ -93,7 +99,7 @@ const FormSecondaryButtons = ({ introUploadIdLink = false, exitOnly = false }: P
       <ConfirmationModal
         open={cancelModalOpen}
         onClose={() => setCancelModalOpen(false)}
-        onConfirm={exitOnly ? undefined : handleCancel}
+        onConfirm={exitOnly ? handleExit : handleCancel}
         confirmType="danger"
         texts={
           exitOnly

--- a/packages/shared-frontend/src/form/RenderForm.tsx
+++ b/packages/shared-frontend/src/form/RenderForm.tsx
@@ -1,6 +1,6 @@
 import { Provider as AkselProvider } from '@navikt/ds-react';
 import { en, nb, nn } from '@navikt/ds-react/locales';
-import { Form, Submission, submissionTypesUtils } from '@navikt/skjemadigitalisering-shared-domain';
+import { Form, Submission } from '@navikt/skjemadigitalisering-shared-domain';
 import { useLocation } from 'react-router';
 import { FyllutAppConfig, FyllutAppConfigProvider, useFyllutAppConfig } from '../context/fyllut/FyllutAppConfigContext';
 import { FyllutLanguage, FyllutLanguageProvider } from '../context/fyllut/FyllutLanguageContext';
@@ -18,6 +18,7 @@ import {
   ValidationProvider,
 } from './framework';
 import { NologinTokenProvider } from './nologin-token/NologinTokenContext';
+import { resolveDefaultSubmissionMethod } from './submissionMethodResolution';
 import SubmissionMethodSelection from './SubmissionMethodSelection';
 import useSubmitters from './useSubmitters';
 import Wizard from './wizard/Wizard';
@@ -41,23 +42,10 @@ const RenderFormContent = ({
   currentLanguage: string;
 }) => {
   const { submissionMethod, logger, config } = useFyllutAppConfig();
-  const { pathname } = useLocation();
   const persistence = useSubmitters(form, initialInnsendingsId);
   const hydratedInitialSubmission = applyPrefilledValuesToSubmission(form, initialSubmission, currentLanguage);
-  const defaultSubmissionMethod = submissionMethod === undefined && pathname !== `/${form.path}` ? 'paper' : undefined;
-  const effectiveSubmissionMethod =
-    submissionMethod ??
-    defaultSubmissionMethod ??
-    (submissionTypesUtils.isPaperSubmissionOnly(form.properties.submissionTypes)
-      ? 'paper'
-      : submissionTypesUtils.isDigitalSubmissionOnly(form.properties.submissionTypes)
-        ? 'digital'
-        : submissionTypesUtils.isDigitalNoLoginSubmissionOnly(form.properties.submissionTypes)
-          ? 'digitalnologin'
-          : submissionTypesUtils.isPaperNoCoverPageSubmissionOnly(form.properties.submissionTypes) &&
-              (form.properties.submissionTypes?.length ?? 0) > 0
-            ? 'papernocoverpage'
-            : undefined);
+  const defaultSubmissionMethod = resolveDefaultSubmissionMethod(form.properties.submissionTypes);
+  const effectiveSubmissionMethod = submissionMethod ?? defaultSubmissionMethod;
   const shouldRenderWizard =
     effectiveSubmissionMethod !== undefined || (form.properties.submissionTypes?.length ?? 0) === 0;
 

--- a/packages/shared-frontend/src/form/Summary.tsx
+++ b/packages/shared-frontend/src/form/Summary.tsx
@@ -30,6 +30,7 @@ import { PREPARE_LETTER_KEY, PREPARE_NO_SUBMISSION_KEY } from './wizard/constant
 const toInputId = (submissionPath: string) => `input-${submissionPath.replace(/[.[\]]/g, '-')}`;
 const DELETED_DRAFT_STORAGE_KEY = 'fyllut:new-render:deleted-draft-id';
 const DELETED_DRAFT_QUERY_PARAM = 'deletedDraft';
+const DISCARDED_SUBMISSION_STORAGE_KEY = 'fyllut:new-render:discarded-submission';
 
 interface Props {
   onBack: () => void;
@@ -41,12 +42,13 @@ const Summary = ({ onBack, onNavigateToError, onNavigateToStep }: Props) => {
   const appConfig = useFyllutAppConfig();
   const { translate, currentLanguage } = useFyllutLanguage();
   const { form, activeComponents } = useFormDefinition();
-  const { submission } = useSubmissionState();
+  const { submission, setSubmission } = useSubmissionState();
   const { pagesWithErrors, validatePages, getErrorsForPages, shouldShowSummaryForSummaryPage } = useValidation();
   const { submit, status, canSubmit } = useFormPersistence();
   const { handleDownloadFile } = useAttachmentUpload();
   const { search } = useLocation();
   const [attemptedSubmitWithErrors, setAttemptedSubmitWithErrors] = useState(false);
+  const [hasDiscardedSubmission] = useState(() => sessionStorage.getItem(DISCARDED_SUBMISSION_STORAGE_KEY) === '1');
   const attachmentPanel = navFormUtils.getActiveAttachmentPanelFromForm(form, submission);
   const activePanels = navFormUtils.getActivePanelsFromForm(form, submission);
   const isNoSubmissionFlow =
@@ -99,6 +101,12 @@ const Summary = ({ onBack, onNavigateToError, onNavigateToStep }: Props) => {
       sessionStorage.removeItem(DELETED_DRAFT_STORAGE_KEY);
     }
   }, [isDeletedDraftSummary]);
+  useEffect(() => {
+    if (hasDiscardedSubmission) {
+      sessionStorage.removeItem(DISCARDED_SUBMISSION_STORAGE_KEY);
+      setSubmission(undefined);
+    }
+  }, [hasDiscardedSubmission, setSubmission]);
   const shouldShowEmptyDigitalSummaryErrors =
     (appConfig.submissionMethod === 'digital' || appConfig.submissionMethod === 'digitalnologin') &&
     !hasSubmissionData &&
@@ -112,6 +120,7 @@ const Summary = ({ onBack, onNavigateToError, onNavigateToStep }: Props) => {
         : TEXTS.grensesnitt.navigation.sendToNav;
   const hasSummaryValidationErrors =
     isDeletedDraftSummary ||
+    hasDiscardedSubmission ||
     (effectiveSummaryErrors.length > 0 &&
       (attemptedSubmitWithErrors ||
         shouldShowSummaryForSummaryPage() ||

--- a/packages/shared-frontend/src/form/submissionMethodResolution.ts
+++ b/packages/shared-frontend/src/form/submissionMethodResolution.ts
@@ -1,0 +1,27 @@
+import { SubmissionMethod, SubmissionType, submissionTypesUtils } from '@navikt/skjemadigitalisering-shared-domain';
+
+const resolveDefaultSubmissionMethod = (submissionTypes?: SubmissionType[]): SubmissionMethod | undefined => {
+  if (submissionTypes?.length === 0) {
+    return undefined;
+  }
+
+  if (submissionTypesUtils.isPaperSubmissionOnly(submissionTypes)) {
+    return 'paper';
+  }
+
+  if (submissionTypesUtils.isDigitalSubmissionOnly(submissionTypes)) {
+    return 'digital';
+  }
+
+  if (submissionTypesUtils.isDigitalNoLoginSubmissionOnly(submissionTypes)) {
+    return 'digitalnologin';
+  }
+
+  if (submissionTypesUtils.isPaperNoCoverPageSubmissionOnly(submissionTypes)) {
+    return 'papernocoverpage';
+  }
+
+  return undefined;
+};
+
+export { resolveDefaultSubmissionMethod };

--- a/packages/shared-frontend/src/form/wizard/PanelStep.tsx
+++ b/packages/shared-frontend/src/form/wizard/PanelStep.tsx
@@ -34,7 +34,7 @@ const PanelStep = ({ form }: { form: Form }) => {
 
   useEffect(() => {
     if (panels.length > 0 && panelSlug && !panels.some((panel) => panel.key === panelSlug)) {
-      goToPanel(panels[0].key);
+      goToPanel(panels[0].key, { redirect: true });
     }
   }, [goToPanel, panelSlug, panels]);
 

--- a/packages/shared-frontend/src/form/wizard/Wizard.tsx
+++ b/packages/shared-frontend/src/form/wizard/Wizard.tsx
@@ -45,6 +45,8 @@ const WizardLayout = ({ form }: { form: Form }) => {
 
   const onStepClick = (key: string) => {
     hideSummary();
+    const { redirect: _inheritedRedirect, ...inheritedState } =
+      typeof state === 'object' && state ? (state as Record<string, unknown>) : {};
     navigate(
       {
         pathname: key === '' ? `/${form.path}` : `/${form.path}/${key}`,
@@ -52,7 +54,7 @@ const WizardLayout = ({ form }: { form: Form }) => {
       },
       {
         state: {
-          ...(typeof state === 'object' && state ? state : {}),
+          ...inheritedState,
           validationErrorPages: Array.from(pagesWithErrors),
         },
       },

--- a/packages/shared-frontend/src/form/wizard/WizardStep.tsx
+++ b/packages/shared-frontend/src/form/wizard/WizardStep.tsx
@@ -1,5 +1,6 @@
 import { Form, navFormUtils, TEXTS } from '@navikt/skjemadigitalisering-shared-domain';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router';
 import { FormHeader, FormStepper, StepperProvider } from '../framework';
 import { ATTACHMENTS_KEY, INTRO_KEY, SUMMARY_KEY } from './constants';
 
@@ -11,6 +12,34 @@ interface Props {
   children: ReactNode;
 }
 
+const PAGE_TITLE_ID = 'page-title';
+const EDITABLE_FIELD_SELECTOR = 'input, select, textarea';
+
+/**
+ * The page title is focused after step navigation, but the new step may render in several passes,
+ * which can replace the heading element and drop the focus. Reapply focus for a few frames, without
+ * stealing focus from a field the user is editing or from another element that got focus meanwhile.
+ */
+const focusPageTitleAfterNavigation = (remainingAttempts = 10, isFirstAttempt = true) => {
+  const pageTitle = document.getElementById(PAGE_TITLE_ID);
+  const activeElement = document.activeElement;
+
+  if (activeElement?.matches(EDITABLE_FIELD_SELECTOR)) {
+    return;
+  }
+
+  const canTakeFocus = isFirstAttempt || !activeElement || activeElement === document.body;
+  if (canTakeFocus) {
+    pageTitle?.focus();
+  } else if (activeElement !== pageTitle) {
+    return;
+  }
+
+  if (remainingAttempts > 1) {
+    requestAnimationFrame(() => focusPageTitleAfterNavigation(remainingAttempts - 1, false));
+  }
+};
+
 const WizardStep = ({ form, activeIndex, pageTitle, onStepClick, children }: Props) => (
   <WizardStepContent form={form} activeIndex={activeIndex} pageTitle={pageTitle} onStepClick={onStepClick}>
     {children}
@@ -18,6 +47,8 @@ const WizardStep = ({ form, activeIndex, pageTitle, onStepClick, children }: Pro
 );
 
 const WizardStepContent = ({ form, activeIndex, pageTitle, onStepClick, children }: Props) => {
+  const { pathname, hash, state } = useLocation();
+  const previousPathname = useRef<string | undefined>(undefined);
   const trailingSteps = [
     ...(navFormUtils.hasAttachment(form) ? [{ key: ATTACHMENTS_KEY, label: TEXTS.statiske.attachment.title }] : []),
     { key: SUMMARY_KEY, label: TEXTS.statiske.summaryPage.title },
@@ -29,6 +60,24 @@ const WizardStepContent = ({ form, activeIndex, pageTitle, onStepClick, children
     }
     onStepClick(key);
   };
+
+  useEffect(() => {
+    const isNavigationBetweenSteps = previousPathname.current !== undefined && previousPathname.current !== pathname;
+    previousPathname.current = pathname;
+
+    if (!isNavigationBetweenSteps) {
+      return;
+    }
+
+    const locationState = typeof state === 'object' && state ? (state as Record<string, unknown>) : undefined;
+    const hasFieldFocusTarget = Boolean(hash || locationState?.focusId);
+    const isRedirect = locationState?.redirect === true;
+    if (hasFieldFocusTarget || isRedirect) {
+      return;
+    }
+
+    focusPageTitleAfterNavigation();
+  }, [hash, pathname, state]);
 
   return (
     <StepperProvider isOpen={isStepperOpen}>

--- a/packages/shared-frontend/src/form/wizard/useWizardNavigation.ts
+++ b/packages/shared-frontend/src/form/wizard/useWizardNavigation.ts
@@ -9,6 +9,7 @@ interface WizardNavigationState {
   validationErrorPages?: string[];
   initialSubmission?: Submission;
   preserveInitialSubmission?: true;
+  redirect?: true;
 }
 
 type StepKind = 'intro' | 'panel' | 'attachment' | 'summary';
@@ -21,13 +22,18 @@ const useWizardNavigation = (from: StepKind) => {
   const prefix = from === 'intro' ? '' : '../';
 
   const buildState = useCallback(
-    (extra?: WizardNavigationState): WizardNavigationState => ({
-      ...(typeof state === 'object' && state ? state : {}),
-      initialSubmission: submission,
-      preserveInitialSubmission: true,
-      validationErrorPages: Array.from(pagesWithErrors),
-      ...extra,
-    }),
+    (extra?: WizardNavigationState): WizardNavigationState => {
+      const { redirect: _inheritedRedirect, ...inheritedState } =
+        typeof state === 'object' && state ? (state as WizardNavigationState) : ({} as WizardNavigationState);
+
+      return {
+        ...inheritedState,
+        initialSubmission: submission,
+        preserveInitialSubmission: true,
+        validationErrorPages: Array.from(pagesWithErrors),
+        ...extra,
+      };
+    },
     [pagesWithErrors, state, submission],
   );
 
@@ -42,7 +48,10 @@ const useWizardNavigation = (from: StepKind) => {
         return;
       }
       hideSummary();
-      navigate({ pathname: `${prefix}${panelKey}`, search }, { state: buildState(extra) });
+      navigate(
+        { pathname: `${prefix}${panelKey}`, search },
+        { state: buildState(extra), replace: extra?.redirect === true },
+      );
     },
     [buildState, hideSummary, navigate, prefix, search],
   );

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -19,6 +19,7 @@ import {
   shouldUseLegacyPageForNewRenderer,
 } from './form/digitalDraftUtils';
 import RenderForm from './form/RenderForm';
+import { resolveDefaultSubmissionMethod } from './form/submissionMethodResolution';
 import { FormButtonRow, FormNextButton, FormPrevButton } from './layout/FormButtonRow';
 import FormHeader from './layout/FormHeader';
 import FormIcon from './layout/FormIcon';
@@ -78,6 +79,7 @@ export {
   RenderForm,
   RenderInputForm,
   RenderSummaryForm,
+  resolveDefaultSubmissionMethod,
   SharedFrontendBoundary,
   sharedFrontendPackageName,
   shouldUseLegacyPageForNewRenderer,


### PR DESCRIPTION
_Root causes & fixes (all in the new render framework, no test/mock changes)_

**focus-handling.cy.ts** — the new wizard never moved focus to the page heading after navigation (the old renderer did this in  shared-components/src/pages/FormLayout.tsx ).

 -  wizard/WizardStep.tsx : focus  #page-title  after step navigation, retried over a few frames (the new step renders in several passes and replaces the heading node), skipping field-focus targets and never stealing focus from an input the user is editing.
 -  wizard/PanelStep.tsx  /  useWizardNavigation.ts  /  Wizard.tsx : unknown-panel-slug redirects are now marked  redirect: true  and use  replace , so they don't trigger heading focus (that redirect was stealing focus mid-typing and wiping typed values — caught as a regression in  currency-and-account.cy.ts  during verification).

**conditional-rendering.cy.ts**

 -  FormLanguageSelector.tsx : language switch used a plain anchor, losing the in-memory paper submission; now client-navigates with the submission preserved.
 -  data-grid/InputDataGrid.tsx : custom conditionals inside a  container  in a datagrid received the whole datagrid row instead of the nearest container row (Formio expects  row.<containerKey> ); row scoping is now recursive (+ vitest coverage).
 -  RenderInputComponent.tsx : wrapper only emitted  formio-component-<key> ; now also emits  formio-component-<type>  as the legacy renderer did.

**form-navigation.cy.ts**

 - New  form/submissionMethodResolution.ts  with  resolveDefaultSubmissionMethod , used by  RenderForm.tsx  and fyllut's  FormPageWrapper.tsx : direct routes without  sub  were hard-forced to  paper , breaking forms with  submissionTypes: []  and  PAPER_NO_COVER_PAGE .
 -  FormSecondaryButtons.tsx  /  Summary.tsx : "Avslutt" now actually discards the submission (marker + clearing), so returning via browser back shows the incomplete-form state instead of a restored valid summary — following the existing deleted-draft pattern.

**Verification**

 -  form/*  (CI job "fyllut form"): 83/83 pass (was 74/83).
 - Bonus:  other/submission-types.cy.ts  went from 5 CI failures to 31/31 pass.
 - No regressions: all component suites 433/437 — only  sender.cy.ts  (4, pre-existing backend  PdfSignature  error),  driving-list / your-information  (3/17, identical to CI),  digital-submission/mellomlagring2  (12 pass/13 fail, byte-identical to CI), and remaining  other  failures unchanged or fewer than CI.
 -  shared-frontend  vitest 124/124,  tsc  clean for shared-frontend and fyllut, eslint clean (one pre-existing warning).