### PR TITLE
docs: form loading traps and fyllut deploy topology

### DIFF
--- a/.github/skills/form-definition-loading/SKILL.md
+++ b/.github/skills/form-definition-loading/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: form-definition-loading
+description: >-
+    How form definitions reach fyllut-backend from static files or forms-api,
+    and the traps that silently drop form fields. Use this when adding a field
+    from forms-api, changing form loading, or relying on form metadata such as
+    publicationId, revision or status.
+---
+
+# Form definition loading
+
+## Goal
+
+Add or consume a form field without silently losing it in one of the two
+loading paths.
+
+Every trap below fails **silently**: the field arrives as `undefined`, nothing
+throws, and the missing data only shows up as subtly wrong output much later.
+
+## Two loading paths
+
+`fyllut-backend` resolves form definitions in one of two ways, decided by
+`FORMS_SOURCE`:
+
+| Source             | Used by                                   | Comes from                                                 |
+| ------------------ | ----------------------------------------- | ---------------------------------------------------------- |
+| `static`           | prod, dev                                 | published JSON files bundled from `skjemautfylling-formio` |
+| `formsapi-staging` | preprod, preprod-alt, delingslenke, local | forms-api, current revision (may be an unpublished draft)  |
+
+The static path serves **published snapshots**. The forms-api path serves the
+**latest revision**, which is often a draft ahead of what has been published.
+
+## Trap 1: `FORMS_SOURCE` does not identify the environment
+
+Both prod and dev use `static`. Never use the forms source as a proxy for "is
+this production". Use explicit configuration instead.
+
+## Trap 2: the static path maps through an explicit field whitelist
+
+The backwards-compatibility mapper that converts stored form JSON into the
+shared form model destructures a fixed list of fields and rebuilds the object.
+Fields not in that list are dropped, even when they exist in the JSON on disk.
+
+Adding a field from forms-api therefore takes **two** edits:
+
+1. add it to the shared form model, and
+2. add it to the backwards-compatibility mapper.
+
+Do only the first and the forms-api path works while the static path silently
+returns `undefined` — meaning it breaks in production and dev, and works
+everywhere you are likely to test.
+
+## Trap 3: `select` lists are per-call-site and drift apart
+
+Callers pass an explicit `select` list of the fields they want. Fields left out
+are simply absent from the response; there is no error. Several routes render
+the same document but historically requested different fields.
+
+When a feature spans more than one route, align the `select` lists across all
+of them in the same change, and add a test that covers each route rather than
+just one.
+
+## Trap 4: `publicationId` is only trustworthy when `status` is `published`
+
+forms-api returns the **latest publication's** `publicationId` even when the
+current revision is a draft ahead of that publication (`status: pending`). The
+id then describes different components than the ones you just loaded.
+
+Guard every use:
+
+```
+const trustworthy = status === 'published' && publicationId;
+```
+
+Static snapshots are always `published`, so the guard is a no-op there and only
+matters on the forms-api path — which is exactly where local and test
+environments run.
+
+Related background on what a publication covers lives in the forms-api
+repository.
+
+## Checklist for adding a forms-api field
+
+- [ ] Field added to the shared form model
+- [ ] Field added to the backwards-compatibility mapper used by the static path
+- [ ] Field added to the `select` list of **every** call site that needs it
+- [ ] Behaviour verified on both loading paths, not just the one running locally

--- a/.github/skills/fyllut-deploy-topology/SKILL.md
+++ b/.github/skills/fyllut-deploy-topology/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: fyllut-deploy-topology
+description: >-
+    How FyllUt is built and deployed across two repositories, and why GIT_SHA
+    means different things depending on which repository built the image. Use
+    this when adding a NAIS environment variable, changing deploy workflows, or
+    interpreting a commit hash shown by the application.
+---
+
+# FyllUt deploy topology
+
+## Goal
+
+Understand which repository contributes what to a running FyllUt instance,
+before changing deploy configuration or reasoning about version identifiers.
+
+## Two repositories, one application
+
+FyllUt is assembled from two repositories:
+
+- **this monorepo** builds the `fyllut-base` image containing the application
+  code, and owns the NAIS configuration under `.nais/fyllut/`
+- **`skjemautfylling-formio`** holds published form definitions, translations
+  and resources, and builds the production image `FROM` `fyllut-base`
+
+Production deploys are therefore **driven from `skjemautfylling-formio`**, not
+from here — and so are `dev` and `delingslenke`. That repository pins the
+monorepo commit it builds on in a file, and during deploy it fetches
+`.nais/fyllut/config.yaml` and the environment's variable file from this
+repository **at that pinned commit**.
+
+`preprod` and `preprod-alt` are the exception: they are deployed from this
+repository's manual deploy workflow and run `fyllut-base` directly, with NAIS
+configuration read straight from the working tree.
+
+Two consequences worth knowing:
+
+- for environments deployed from `skjemautfylling-formio`, application code and
+  NAIS configuration always ship together, so a new environment variable and the
+  code reading it deploy as one unit — no ordering constraint between the
+  repositories
+- editing `.nais/fyllut/*.yaml` here reaches `preprod`/`preprod-alt`
+  immediately, but does not reach `prod`, `dev` or `delingslenke` until
+  `skjemautfylling-formio` publishes and pins a monorepo commit containing it
+
+## `GIT_SHA` means different things per environment
+
+The base image sets **both** `GIT_SHA` and `MONOREPO_GIT_SHA` to the monorepo
+commit. Images built in `skjemautfylling-formio` then **override `GIT_SHA`**
+with that repository's own commit.
+
+| Environment             | Image built in           | `GIT_SHA`                                       | `MONOREPO_GIT_SHA`      |
+| ----------------------- | ------------------------ | ----------------------------------------------- | ----------------------- |
+| prod, dev, delingslenke | `skjemautfylling-formio` | content commit — forms, translations, resources | application code commit |
+| preprod, preprod-alt    | this monorepo            | application code commit                         | application code commit |
+
+So `GIT_SHA` answers "which application build" in some environments and "which
+content snapshot" in others — same name, different meaning. When you need the
+application code version unambiguously, use `MONOREPO_GIT_SHA`.
+
+Because the content commit changes whenever _any_ form is published, it cannot
+tell you whether one particular form changed.
+
+## Adding a NAIS environment variable
+
+- [ ] Declared in the shared `.nais/fyllut/config.yaml` template
+- [ ] Set explicitly in **every** environment variable file, including
+      production — do not rely on an implicit default to distinguish
+      environments
+- [ ] Given a safe fallback in backend configuration, so an unset value fails
+      obviously rather than looking like production
+- [ ] Remember `prod`, `dev` and `delingslenke` pick the change up only once
+      `skjemautfylling-formio` pins a monorepo commit containing it, while
+      `preprod`/`preprod-alt` get it straight away


### PR DESCRIPTION
Documents behaviour uncovered while designing #2153 (spec #2152). Docs only, no code changes.

Two new skills under `.github/skills/`, following the repo's own guidance that specific guidance belongs in skills rather than `AGENTS.md`:

**`form-definition-loading`** — the static vs forms-api loading paths and three traps that all fail *silently*:
- the backwards-compatibility mapper used by the static path destructures an explicit field whitelist, so a new forms-api field needs adding in two places or it silently vanishes in prod and dev while working everywhere you'd normally test
- `select` lists are per-call-site and have drifted apart; an unrequested field is `undefined`, not an error
- `publicationId` is only trustworthy when `status` is `published` — forms-api returns the latest publication's id even for drafts ahead of it
- also notes that `FORMS_SOURCE` does not identify the environment, since prod and dev both use `static`

**`fyllut-deploy-topology`** — which repository builds which image, how NAIS config is fetched from this repo at the commit pinned in `skjemautfylling-formio`, and why `GIT_SHA` means the content commit for prod/dev/delingslenke but the application commit for preprod/preprod-alt. Includes a checklist for adding a NAIS environment variable.

Deliberately documents rules rather than counts, since coverage numbers go stale quickly.